### PR TITLE
Add Columns Attribute to Dataset

### DIFF
--- a/opencosmo/dataset/dataset.py
+++ b/opencosmo/dataset/dataset.py
@@ -63,6 +63,17 @@ class Dataset:
         return self.__handler.__exit__()
 
     @property
+    def columns(self) -> list[str]:
+        """
+        The names of the columns in this dataset.
+
+        Returns
+        -------
+        columns: list[str]
+        """
+        return list(self.__builders.keys())
+
+    @property
     def cosmology(self) -> Cosmology:
         """
         The cosmology of the simulation this dataset is drawn from as

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -27,7 +27,7 @@ def test_read(input_path):
 def test_all_columns_included(input_path):
     dataset = oc.read(input_path)
     cols = set(dataset._Dataset__handler._DatasetHandler__group.keys())
-    cols_read = set(dataset.data.columns)
+    cols_read = set(dataset.columns)
     assert cols == cols_read
 
 


### PR DESCRIPTION
The names of the columns in a given dataset can now be access with the `columns` attribute.
