### PR TITLE
Better MPI Usage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: setup mpi
+        uses: mpi4py/setup-mpi@v1
       - uses: ammaraskar/sphinx-action@master
         with:
           docs-folder: "docs"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,12 +46,3 @@ jobs:
           push: ${{ inputs.push-docker }}
           targets: dev
 
-  build-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: setup mpi
-        uses: mpi4py/setup-mpi@v1
-      - uses: ammaraskar/sphinx-action@master
-        with:
-          docs-folder: "docs"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,9 @@ version: 2
 # Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04
+  apt_packages:
+    - openmpi-bin
+    - libopenmpi-dev
   tools:
     python: "3.13"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx_rtd_theme>=3.0.2
 autodoc_pydantic>=2.2.0
+mpi4py>=4.0

--- a/opencosmo/dataset/handler.py
+++ b/opencosmo/dataset/handler.py
@@ -9,15 +9,8 @@ from astropy.table import Column, Table  # type: ignore
 from opencosmo.dataset.index import DataIndex
 from opencosmo.header import OpenCosmoHeader
 from opencosmo.io.schemas import DatasetSchema
+from opencosmo.mpi import get_comm_world
 from opencosmo.spatial.tree import Tree
-
-try:
-    from mpi4py import MPI
-
-    if MPI.COMM_WORLD.Get_size() == 1:
-        MPI = None  # type: ignore
-except ImportError:
-    MPI = None  # type: ignore
 
 
 class DatasetHandler:
@@ -51,8 +44,8 @@ class DatasetHandler:
         return self.__file.close()
 
     def collect(self, columns: Iterable[str], index: DataIndex) -> DatasetHandler:
-        if MPI is not None:
-            indices = MPI.COMM_WORLD.allgather(index)
+        if (comm := get_comm_world()) is not None:
+            indices = comm.allgather(index)
             new_index = indices[0].concatenate(*indices[1:])
         else:
             new_index = index

--- a/opencosmo/file.py
+++ b/opencosmo/file.py
@@ -5,10 +5,7 @@ from typing import Any, Callable, Concatenate, TypeVar
 
 import h5py
 
-from opencosmo.mpi import get_comm_world, get_mpi
-
-MPI = get_mpi()
-
+from opencosmo.mpi import get_comm_world
 
 H5Resource = TypeVar("H5Resource", h5py.File, h5py.Group, h5py.Dataset)
 H5Reader = Callable[Concatenate[H5Resource, ...], Any]
@@ -73,15 +70,16 @@ def broadcast_read(func: H5Reader) -> H5Reader:
     @wraps(func)
     def wrapper(file: h5py.File | Path | str, *args, **kwargs):
         output = None
-        if MPI is None or get_comm_world().Get_rank() == 0:
+        comm = get_comm_world()
+        if comm is None or comm.Get_rank() == 0:
             try:
                 output = func(file, *args, **kwargs)
             except Exception as e:
                 output = e
-        if MPI is not None:
+        if comm is not None:
             # Broadcasting the error ensures other ranks
             # will raise the exception and quit.
-            output = get_comm_world().bcast(output, root=0)
+            output = comm.bcast(output, root=0)
         if isinstance(output, Exception):
             raise output
         return output

--- a/opencosmo/header.py
+++ b/opencosmo/header.py
@@ -8,11 +8,6 @@ from opencosmo import cosmology as cosmo
 from opencosmo import parameters
 from opencosmo.file import broadcast_read, file_reader, file_writer
 
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None  # type: ignore
-
 
 class OpenCosmoHeader:
     """

--- a/opencosmo/io/io.py
+++ b/opencosmo/io/io.py
@@ -225,7 +225,7 @@ def write_parallel(file: Path, file_schema: FileSchema):
             new_schema.allocate(f)
 
     comm.Barrier()
-    writer = file_schema.into_writer()
+    writer = file_schema.into_writer(comm)
 
     try:
         with h5py.File(file, "a", driver="mpio", comm=comm) as f:

--- a/opencosmo/io/protocols.py
+++ b/opencosmo/io/protocols.py
@@ -5,7 +5,7 @@ import h5py
 try:
     from mpi4py import MPI
 except ImportError:
-    MPI = None
+    MPI = None  # type: ignore
 
 
 class DataSchema(Protocol):

--- a/opencosmo/io/protocols.py
+++ b/opencosmo/io/protocols.py
@@ -1,6 +1,11 @@
-from typing import Protocol
+from typing import Optional, Protocol
 
 import h5py
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
 
 
 class DataSchema(Protocol):
@@ -8,7 +13,7 @@ class DataSchema(Protocol):
     def add_child(self, child: "DataSchema", name: str): ...
     def allocate(self, group: h5py.File | h5py.Group): ...
     def verify(self): ...
-    def into_writer(self): ...
+    def into_writer(self, comm: Optional["MPI.Comm"]): ...
 
 
 class DataWriter(Protocol):

--- a/opencosmo/io/schemas.py
+++ b/opencosmo/io/schemas.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 import h5py
 import hdf5plugin  # type: ignore
@@ -9,10 +9,8 @@ import opencosmo.io.writers as iow
 from opencosmo.dataset.index import DataIndex
 from opencosmo.header import OpenCosmoHeader
 
-try:
+if TYPE_CHECKING:
     from mpi4py import MPI
-except ImportError:
-    MPI = None
 
 ColumnShape = tuple[int, ...]
 

--- a/opencosmo/io/schemas.py
+++ b/opencosmo/io/schemas.py
@@ -357,7 +357,7 @@ class IdxLinkSchema:
         return self.column.verify()
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
-        return iow.IdxLinkWriter(self.column.into_writer(comm))
+        return iow.IdxLinkWriter(self.column.into_writer(comm), comm)
 
 
 class StartSizeLinkSchema:
@@ -398,7 +398,7 @@ class StartSizeLinkSchema:
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
         return iow.StartSizeLinkWriter(
-            self.start.into_writer(comm), self.size.into_writer()
+            self.start.into_writer(comm), self.size.into_writer(), comm
         )
 
 

--- a/opencosmo/io/schemas.py
+++ b/opencosmo/io/schemas.py
@@ -87,7 +87,7 @@ class FileSchema:
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
         children = {
-            name: schema.into_writer() for name, schema in self.children.items()
+            name: schema.into_writer(comm) for name, schema in self.children.items()
         }
         return iow.FileWriter(children)
 
@@ -138,7 +138,9 @@ class SimCollectionSchema:
             child.verify()
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
-        children = {name: child.into_writer() for name, child in self.children.items()}
+        children = {
+            name: child.into_writer(comm) for name, child in self.children.items()
+        }
         return iow.CollectionWriter(children)
 
 
@@ -203,7 +205,9 @@ class StructCollectionSchema:
             ds.allocate(ds_group)
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
-        dataset_writers = {key: val.into_writer() for key, val in self.children.items()}
+        dataset_writers = {
+            key: val.into_writer(comm) for key, val in self.children.items()
+        }
         return iow.CollectionWriter(dataset_writers, self.header)
 
 
@@ -276,8 +280,12 @@ class DatasetSchema:
             link.allocate(link_group)
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
-        column_writers = {name: col.into_writer() for name, col in self.columns.items()}
-        link_writers = {name: link.into_writer() for name, link in self.links.items()}
+        column_writers = {
+            name: col.into_writer(comm) for name, col in self.columns.items()
+        }
+        link_writers = {
+            name: link.into_writer(comm) for name, link in self.links.items()
+        }
 
         return iow.DatasetWriter(column_writers, link_writers, self.header)
 
@@ -349,7 +357,7 @@ class IdxLinkSchema:
         return self.column.verify()
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
-        return iow.IdxLinkWriter(self.column.into_writer())
+        return iow.IdxLinkWriter(self.column.into_writer(comm))
 
 
 class StartSizeLinkSchema:
@@ -390,7 +398,7 @@ class StartSizeLinkSchema:
 
     def into_writer(self, comm: Optional["MPI.Comm"] = None):
         return iow.StartSizeLinkWriter(
-            self.start.into_writer(), self.size.into_writer()
+            self.start.into_writer(comm), self.size.into_writer()
         )
 
 

--- a/opencosmo/io/writers.py
+++ b/opencosmo/io/writers.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import h5py
 import numpy as np
@@ -7,10 +7,8 @@ from opencosmo.dataset.index import DataIndex
 from opencosmo.header import OpenCosmoHeader
 from opencosmo.io import protocols as iop
 
-try:
+if TYPE_CHECKING:
     from mpi4py import MPI
-except ImportError:
-    MPI = None
 
 """
 Writers work in tandem with schemas to create new files. All schemas must have

--- a/opencosmo/mpi.py
+++ b/opencosmo/mpi.py
@@ -4,7 +4,7 @@ from typing import Optional
 try:
     from mpi4py import MPI
 except ImportError:
-    MPI = None
+    MPI = None  # type: ignore
 
 
 @cache

--- a/opencosmo/mpi.py
+++ b/opencosmo/mpi.py
@@ -8,7 +8,7 @@ except ImportError:
 
 
 @cache
-def get_comm_world() -> Optional[MPI.Comm]:
+def get_comm_world() -> Optional["MPI.Comm"]:
     if MPI is None or MPI.COMM_WORLD.Get_size() == 1:
         return None
     return MPI.COMM_WORLD.Dup()

--- a/opencosmo/mpi.py
+++ b/opencosmo/mpi.py
@@ -1,0 +1,18 @@
+from functools import cache
+from typing import Optional
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
+
+
+@cache
+def get_comm_world() -> Optional[MPI.Comm]:
+    if MPI is None or MPI.COMM_WORLD.Get_size() == 1:
+        return None
+    return MPI.COMM_WORLD.Dup()
+
+
+def get_mpi():
+    return MPI

--- a/opencosmo/spatial/tree.py
+++ b/opencosmo/spatial/tree.py
@@ -5,14 +5,14 @@ from typing import Optional
 import h5py
 import numpy as np
 
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None  # type: ignore
-
 from opencosmo.header import OpenCosmoHeader
 from opencosmo.spatial.index import SpatialIndex
 from opencosmo.spatial.octree import OctTreeIndex
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
 
 
 def read_tree(file: h5py.File | h5py.Group, header: OpenCosmoHeader):
@@ -128,7 +128,7 @@ class Tree:
     def apply_mask(
         self,
         mask: np.ndarray,
-        comm: Optional[MPI.Comm] = None,
+        comm: Optional["MPI.Comm"] = None,
         range_: Optional[tuple] = None,
     ) -> Tree:
         """
@@ -164,7 +164,7 @@ class Tree:
         return Tree(self.__index, output_starts, output_sizes)
 
     def __apply_rank_mask(
-        self, mask: np.ndarray, comm: MPI.Comm, range_: tuple[int, int]
+        self, mask: np.ndarray, comm: "MPI.Comm", range_: tuple[int, int]
     ) -> Tree:
         """
         Given a range and a mask, apply the mask to the tree. The mask
@@ -179,10 +179,7 @@ class Tree:
         """
         Write the tree to an HDF5 file. Note that this function
         is not responsible for applying masking. The routine calling this
-        funct
-        MPI = None
-        MPI = None
-        MPI = Noneion should first create a new tree with apply_mask if
+        function should first create a new tree with apply_mask if
         necessary.
         """
         group = file.require_group(dataset_name)

--- a/opencosmo/spatial/tree.py
+++ b/opencosmo/spatial/tree.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import h5py
 import numpy as np
@@ -9,10 +9,8 @@ from opencosmo.header import OpenCosmoHeader
 from opencosmo.spatial.index import SpatialIndex
 from opencosmo.spatial.octree import OctTreeIndex
 
-try:
+if TYPE_CHECKING:
     from mpi4py import MPI
-except ImportError:
-    MPI = None
 
 
 def read_tree(file: h5py.File | h5py.Group, header: OpenCosmoHeader):

--- a/opencosmo/structure/builder.py
+++ b/opencosmo/structure/builder.py
@@ -11,11 +11,6 @@ from opencosmo.dataset.index import ChunkedIndex, DataIndex
 from opencosmo.header import OpenCosmoHeader
 from opencosmo.transformations import units as u
 
-try:
-    from mpi4py import MPI
-except ImportError:
-    MPI = None  # type: ignore
-
 
 class DatasetBuilder(Protocol):
     """


### PR DESCRIPTION
MPI Usage inside the library now use better practieces including:

- COMM_WORLD is duplicated to avoid conflicting with non-library code
- Code that is not-user facing always takes a Comm as a parameter if it needs one

