### PR TITLE
a couple more customization options for visualization

### DIFF
--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -167,7 +167,8 @@ The outputted figure is an array of images, with the shape matching that of the 
         halo_ids = [halo['halo_properties']['unique_tag'] for halo in data.halos()]
 
         # construct 4x4 array of halo ids and make a 4x4 array of dark matter projections
-        fig = halo_projection_array(np.reshape(halo_ids,(4,4)), data, field=("dm","particle_mass"))
+        fig = halo_projection_array(np.reshape(halo_ids,(4,4)), data, 
+                    field=("dm","particle_mass"), width=6.0)
 
     # display the image
     plt.show()

--- a/opencosmo/analysis/yt_utils.py
+++ b/opencosmo/analysis/yt_utils.py
@@ -133,6 +133,7 @@ def create_yt_dataset(
         length_unit="Mpc",
         mass_unit="Msun",
         bbox=bbox,
+        periodicity=(False,False,False),
     )
 
     ds.sph_smoothing_style = "gather"  # seems to give more reliable results


### PR DESCRIPTION
Turned off periodicity in `yt.load_particles` since we're only loading subvolumes. Also added more customization options for textcolors, widths, and projection axes. 

Changed default width for projection to be the full subvolume instead of 6*R200. 