### PR TITLE
Basic Parquet Writer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: install analysis dependencies
         run: uv run opencosmo install haloviz --dev

--- a/changes/+48b1dfbc.feature.rst
+++ b/changes/+48b1dfbc.feature.rst
@@ -1,0 +1,1 @@
+You can now dump datasets and some data from collections to parquet with :py:meth:`opencosmo.io.write_parquet`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,6 @@ mpi4py>=4.0
 numpy==1.26.4
 yt>=4.3
 pyxsim==4.4.2
+pyarrow[parquet]>=21.0.0
+
 

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -1,5 +1,5 @@
-Reading and Writing Data
-========================
+Reading and Writing Data in the OpenCosmo Format
+================================================
 OpenCosmo defines a data format for storing simulation data in hdf5 files. A dataset in this format can be transformed and written by the OpenCosmo library to produce a new file that can be read by others (or yourself at a later date!) using the library.
 
 Options for Reading Data
@@ -34,5 +34,40 @@ Writing data to a new file is straightforward:
    oc.write("my_output.hdf5", ds)
 
 Transformations applied to the data will propogate to the file when written, with the exception of :py:meth:`oc.Dataset.with_units`. When you write data, it will always be stored in the unit convention of the original raw data.
+
+Other Formats
+=============
+
+OpenCosmo support dumping some data into other formats. These new files will not be readable by the toolkit, but may be more convinient for your specific usecase
+
+Parquet
+-------
+
+You can dump a :py:class:`Datast <opencosmo.Dataset>`, :py:class:`Lightcone <opencosmo.Lightcone>`, or parts of a :py:class:`StructureCollection <opencosmo.StructureCollection>` to parquet with :py:meth:`opencosmo.io.write_parquet`. You will need to install pyarrow with parquet support first:
+
+.. code-block:: bash
+
+        pip install "pyarrow[parquet]"
+
+
+A dataset will simply be dumped as a collection of columns. Any querying (selection, filtering, etc.) will persist into the output. Metadata such as unit information and the spatial index will not be included:
+
+.. code-block:: python
+
+        import opencosmo as oc
+        from opencosmo.io import write_parquet
+
+        dataset = oc.open("haloproperties.hdf5")
+        write_parquet("my_dataset.parquet", dataset)
+
+
+You can also write the particles of a :py:class:`StructureCollection <opencosmo.StructureCollection>`. 
+
+.. code-block:: python
+
+   structures = oc.open("haloproperties.hdf5", "haloparticles.hdf5")
+   write_parquet("my_structure/", structures)
+
+This will produce one parquet file for each particle type in the collection. 
 
 

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -38,7 +38,13 @@ Transformations applied to the data will propogate to the file when written, wit
 Other Formats
 =============
 
-OpenCosmo support dumping some data into other formats. These new files will not be readable by the toolkit, but may be more convinient for your specific usecase
+OpenCosmo support dumping some data into other formats. These new files will not be readable by the toolkit, but may be more convinient for your specific usecase. You can install all additional io dependencies with
+
+.. code-block:: bash
+
+   pip install "opencosmo[io]"
+
+or you can install individual output formats (see below).
 
 Parquet
 -------

--- a/docs/source/io_ref.rst
+++ b/docs/source/io_ref.rst
@@ -4,5 +4,6 @@ Reading/Writing
 .. autofunction:: opencosmo.open
 .. autofunction:: opencosmo.write
 .. autofunction:: opencosmo.open_linked_files
+.. autofunction:: opencosmo.io.write_parquet
 .. autofunction:: opencosmo.read
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ test-mpi = [
 [project.scripts]
 opencosmo = "opencosmo.analysis.cli:cli"
 
+[project.optional-dependencies]
+io = [
+    "pyarrow>=21.0.0",
+]
+
 [build-system]
 requires = ["uv_build>=0.8.2,<0.9.0", "pip"]
 build-backend = "uv_build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ opencosmo = "opencosmo.analysis.cli:cli"
 [project.optional-dependencies]
 io = [
     "pyarrow>=21.0.0",
+    "pyarrow[parquet]"
 ]
 
 [build-system]

--- a/src/opencosmo/__init__.py
+++ b/src/opencosmo/__init__.py
@@ -1,5 +1,3 @@
-import hdf5plugin  # type: ignore # noqa: F401
-
 from .collection import (
     Lightcone,
     SimulationCollection,

--- a/src/opencosmo/dataset/dataset.py
+++ b/src/opencosmo/dataset/dataset.py
@@ -15,7 +15,7 @@ import astropy.units as u  # type: ignore
 import numpy as np
 from astropy import units  # type: ignore
 from astropy.cosmology import Cosmology  # type: ignore
-from astropy.table import Column, QTable  # type: ignore
+from astropy.table import QTable  # type: ignore
 
 from opencosmo.dataset.column import ColumnMask, DerivedColumn
 from opencosmo.dataset.state import DatasetState
@@ -245,14 +245,17 @@ class Dataset:
             cn = data.colnames[0]
             data = data[cn]
 
-        if isinstance(data, Column):
-            data = data.value
-
         if output == "numpy":
             if isinstance(data, u.Quantity):
                 data = data.value
             elif isinstance(data, (QTable, dict)):
-                data = {name: col.value for name, col in data.items()}
+                data = dict(data)
+                is_quantity = filter(
+                    lambda v: isinstance(data[v], u.Quantity), data.keys()
+                )
+                for colname in is_quantity:
+                    data[colname] = data[colname].value
+
         if isinstance(data, dict) and len(data) == 1:
             return next(iter(data.values()))
 

--- a/src/opencosmo/io/__init__.py
+++ b/src/opencosmo/io/__init__.py
@@ -1,3 +1,18 @@
 from .io import open, read, write
 
-__all__ = ["read", "write", "open"]
+
+def missing_package_import_error(name, required):
+    raise ValueError(f"Function {name} requires package {required}")
+
+
+__all__ = ["read", "write", "open", "write_parquet"]
+
+
+def __getattr__(name):
+    if name == "write_parquet":
+        try:
+            from .parquet import write_parquet
+        except ImportError:
+            raise ImportError("To use write_parquet you must install pyarrow")
+        return write_parquet
+    raise ImportError(f"cannot import name '{name}' from 'opencosmo.io'")

--- a/src/opencosmo/io/parquet.py
+++ b/src/opencosmo/io/parquet.py
@@ -2,7 +2,7 @@ from os import PathLike
 from pathlib import Path
 from warnings import warn
 
-import pyarrow
+import pyarrow  # type: ignore
 from pyarrow import parquet as pq
 
 import opencosmo as oc
@@ -72,8 +72,6 @@ def __write_structure_collection(
         raise ValueError(
             "Dumping a structure collection to parquet can create multiple files, so the output location should be a directory"
         )
-    elif path.exists() and not overwrite:
-        raise FileExistsError(path)
 
     elif not path.exists():
         path.mkdir(parents=True)

--- a/src/opencosmo/io/parquet.py
+++ b/src/opencosmo/io/parquet.py
@@ -9,20 +9,48 @@ import opencosmo as oc
 from opencosmo.collection.protocols import Collection
 
 
-def write_parquet(path: PathLike, to_write: oc.Dataset | Collection, *args, **kwargs):
+def write_parquet(
+    path: PathLike,
+    to_write: oc.Dataset | Collection,
+    overwrite: bool = False,
+    **kwargs,
+):
+    """
+    Write a dataset or collection to a parquet file at the given path. If you are writing a :py:class:`opencosmo.Dataset`,
+    or :py:class:`opencosmo.Lightcone` the data will be written as a single file at the given path. If you are writing
+    a :py:class:`opencosmo.StructureCollection` the data will be written to several files, one for each type of particle.
+
+    Parameters
+    ----------
+    path: PathLike
+        The path to write the data to. If you are writing a :py:class:`Dataset  <opencosmo.Dataset>`
+        or :py:class:`Lightcone <opencosmo.Lightcone>` this should be a single parquet file. If you
+        are writing a :py:class`StructureCollection <opencosmo.StructureCollection>`, this should be
+        a folder.
+
+    to_write: opencosmo.Dataset | opencosmo.Lighcone | opencosmo.StructureCollection
+        The dataset or collection to write
+
+    overwrite: bool, default = False
+        If true, any existing data at the given path will be overwritten.
+
+
+    """
     if not isinstance(path, Path):
         path = Path(path)
     match to_write:
         case oc.Dataset() | oc.Lightcone():
-            return __write_dataset(path, to_write, *args, **kwargs)
+            return __write_dataset(path, to_write, overwrite, **kwargs)
         case oc.StructureCollection():
-            return __write_structure_collection(path, to_write, *args, **kwargs)
+            return __write_structure_collection(path, to_write, overwrite, **kwargs)
         case _:
             raise ValueError(f"No parquet writer defined for type {type(to_write)}")
 
 
-def __write_dataset(path: Path, dataset: oc.Dataset | oc.Lightcone):
+def __write_dataset(path: Path, dataset: oc.Dataset | oc.Lightcone, overwrite: bool):
     data = dataset.get_data("numpy")
+    if path.exists() and not overwrite:
+        raise FileExistsError(path)
     output = {}
     if not isinstance(data, dict):
         raise NotImplementedError
@@ -37,15 +65,22 @@ def __write_dataset(path: Path, dataset: oc.Dataset | oc.Lightcone):
     pq.write_table(table, path)
 
 
-def __write_structure_collection(path: Path, collection: oc.StructureCollection):
-    if len(collection) > 1:
+def __write_structure_collection(
+    path: Path, collection: oc.StructureCollection, overwrite: bool
+):
+    if path.exists() and not path.is_dir():
         raise ValueError(
-            "write_parquet currently only supports writing a single structure"
+            "Dumping a structure collection to parquet can create multiple files, so the output location should be a directory"
         )
+    elif path.exists() and not overwrite:
+        raise FileExistsError(path)
+
+    elif not path.exists():
+        path.mkdir(parents=True)
 
     for name, dataset in collection.items():
         if "particle" not in name:
             warn(f"write_parquet only supports writing particles, skipping {name}")
             continue
         assert isinstance(dataset, oc.Dataset)
-        __write_dataset(path / f"{name}.parquet", dataset)
+        __write_dataset(path / f"{name}.parquet", dataset, overwrite)

--- a/src/opencosmo/io/parquet.py
+++ b/src/opencosmo/io/parquet.py
@@ -25,10 +25,10 @@ def write_parquet(
     path: PathLike
         The path to write the data to. If you are writing a :py:class:`Dataset  <opencosmo.Dataset>`
         or :py:class:`Lightcone <opencosmo.Lightcone>` this should be a single parquet file. If you
-        are writing a :py:class`StructureCollection <opencosmo.StructureCollection>`, this should be
+        are writing a :py:class:`StructureCollection <opencosmo.StructureCollection>`, this should be
         a folder.
 
-    to_write: opencosmo.Dataset | opencosmo.Lighcone | opencosmo.StructureCollection
+    to_write: opencosmo.Dataset | opencosmo.Lightcone | opencosmo.StructureCollection
         The dataset or collection to write
 
     overwrite: bool, default = False

--- a/src/opencosmo/io/parquet.py
+++ b/src/opencosmo/io/parquet.py
@@ -1,0 +1,45 @@
+from os import PathLike
+from warnings import warn
+
+import numpy as np
+import pyarrow
+
+import opencosmo as oc
+from opencosmo.collection.protocols import Collection
+
+
+def write_parquet(path: PathLike, to_write: oc.Dataset | Collection, *args, **kwargs):
+    match to_write:
+        case oc.Dataset() | oc.Lightcone():
+            return __write_dataset(path, to_write, *args, **kwargs)
+        case oc.StructureCollection():
+            return __write_structure_collection(path, to_write, *args, **kwargs)
+
+
+def __write_dataset(path: PathLike, dataset: oc.Dataset | oc.Lightcone):
+    data = dataset.get_data("numpy")
+    table = pyarrow.table(data)
+    pyarrow.parquet.write_table(table, path)
+
+
+def __write_structure_collection(path: PathLike, collection: oc.StructureCollection):
+    if len(collection) > 1:
+        raise ValueError(
+            "write_parquet currently only supports writing a single structure"
+        )
+    data: dict[str, np.ndarray] = {}
+    for name, dataset in collection.items():
+        if "particle" not in name:
+            warn(f"write_parquet only supports writing particles, skipping {name}")
+        assert isinstance(dataset, oc.Dataset)
+        prefix = name.split("_")[0]
+        particle_data = dataset.get_data("numpy")
+        if not isinstance(particle_data, dict):
+            particle_data = {dataset.columns[0]: particle_data}
+
+        particle_data = {
+            f"{prefix}_{cname}": cdata for cname, cdata in particle_data.items()
+        }
+        data.update(particle_data)
+    table = pyarrow.table(data)
+    pyarrow.parquet.write_table(table, path)

--- a/src/opencosmo/io/parquet.py
+++ b/src/opencosmo/io/parquet.py
@@ -1,45 +1,51 @@
 from os import PathLike
+from pathlib import Path
 from warnings import warn
 
-import numpy as np
 import pyarrow
+from pyarrow import parquet as pq
 
 import opencosmo as oc
 from opencosmo.collection.protocols import Collection
 
 
 def write_parquet(path: PathLike, to_write: oc.Dataset | Collection, *args, **kwargs):
+    if not isinstance(path, Path):
+        path = Path(path)
     match to_write:
         case oc.Dataset() | oc.Lightcone():
             return __write_dataset(path, to_write, *args, **kwargs)
         case oc.StructureCollection():
             return __write_structure_collection(path, to_write, *args, **kwargs)
+        case _:
+            raise ValueError(f"No parquet writer defined for type {type(to_write)}")
 
 
-def __write_dataset(path: PathLike, dataset: oc.Dataset | oc.Lightcone):
+def __write_dataset(path: Path, dataset: oc.Dataset | oc.Lightcone):
     data = dataset.get_data("numpy")
-    table = pyarrow.table(data)
-    pyarrow.parquet.write_table(table, path)
+    output = {}
+    if not isinstance(data, dict):
+        raise NotImplementedError
+    for name, column in data.items():
+        if column.dtype.names is None:
+            output[name] = column
+            continue
+        outputs = {f"{name}_{cname}": column[cname] for cname in column.dtype.names}
+        output.update(outputs)
+
+    table = pyarrow.table(output)
+    pq.write_table(table, path)
 
 
-def __write_structure_collection(path: PathLike, collection: oc.StructureCollection):
+def __write_structure_collection(path: Path, collection: oc.StructureCollection):
     if len(collection) > 1:
         raise ValueError(
             "write_parquet currently only supports writing a single structure"
         )
-    data: dict[str, np.ndarray] = {}
+
     for name, dataset in collection.items():
         if "particle" not in name:
             warn(f"write_parquet only supports writing particles, skipping {name}")
+            continue
         assert isinstance(dataset, oc.Dataset)
-        prefix = name.split("_")[0]
-        particle_data = dataset.get_data("numpy")
-        if not isinstance(particle_data, dict):
-            particle_data = {dataset.columns[0]: particle_data}
-
-        particle_data = {
-            f"{prefix}_{cname}": cdata for cname, cdata in particle_data.items()
-        }
-        data.update(particle_data)
-    table = pyarrow.table(data)
-    pyarrow.parquet.write_table(table, path)
+        __write_dataset(path / f"{name}.parquet", dataset)

--- a/test/test_parquet.py
+++ b/test/test_parquet.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from pyarrow import parquet as pq
+
+import opencosmo as oc
+from opencosmo.io import write_parquet
+
+
+@pytest.fixture
+def input_path(snapshot_path):
+    return snapshot_path / "haloproperties.hdf5"
+
+
+@pytest.fixture
+def halo_structure_paths(snapshot_path: Path):
+    files = ["haloparticles.hdf5", "haloproperties.hdf5", "sodproperties.hdf5"]
+    hdf_files = [snapshot_path / file for file in files]
+    return list(hdf_files)
+
+
+@pytest.fixture
+def haloproperties_600_path(lightcone_path):
+    return lightcone_path / "step_600" / "haloproperties.hdf5"
+
+
+@pytest.fixture
+def haloproperties_601_path(lightcone_path):
+    return lightcone_path / "step_601" / "haloproperties.hdf5"
+
+
+def test_dump_dataset(input_path, tmp_path):
+    dataset = oc.open(input_path)
+    write_parquet(tmp_path / "test.parquet", dataset)
+    table = pq.read_table(tmp_path / "test.parquet")
+    data = dataset.get_data("numpy")
+
+    for col in dataset.columns:
+        assert np.all(data[col] == table[col])
+
+
+def test_dump_dataset_unit_transition(input_path, tmp_path):
+    dataset = oc.open(input_path).with_units("physical")
+    write_parquet(tmp_path / "test.parquet", dataset)
+    table = pq.read_table(tmp_path / "test.parquet")
+    data = dataset.get_data("numpy")
+
+    for col in dataset.columns:
+        assert np.all(data[col] == table[col])
+
+
+def test_dump_lightcone(haloproperties_600_path, haloproperties_601_path, tmp_path):
+    dataset = oc.open(haloproperties_600_path, haloproperties_601_path)
+    write_parquet(tmp_path / "test.parquet", dataset)
+    table = pq.read_table(tmp_path / "test.parquet")
+    data = dataset.get_data("numpy")
+
+    for col in dataset.columns:
+        coldata = data[col]
+        if coldata.dtype.names is not None:
+            continue
+
+        assert np.all(data[col] == table[col])
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_dump_structure(halo_structure_paths, tmp_path):
+    dataset = (
+        oc.open(*halo_structure_paths).filter(oc.col("fof_halo_mass") > 1e14).take(1)
+    )
+    write_parquet(tmp_path, dataset)
+    _ = list(tmp_path.glob("*.parquet"))
+    assert False

--- a/test/test_parquet.py
+++ b/test/test_parquet.py
@@ -70,5 +70,13 @@ def test_dump_structure(halo_structure_paths, tmp_path):
         oc.open(*halo_structure_paths).filter(oc.col("fof_halo_mass") > 1e14).take(1)
     )
     write_parquet(tmp_path, dataset)
-    _ = list(tmp_path.glob("*.parquet"))
-    assert False
+    files = list(tmp_path.glob("*.parquet"))
+    data = {}
+    for file in files:
+        table = pq.read_table(file)
+        data[file.stem] = table
+
+    for data_type, table in data.items():
+        oc_data = dataset[data_type].get_data("numpy")
+        for column_name in oc_data.keys():
+            assert np.all(oc_data[column_name] == table[column_name])

--- a/uv.lock
+++ b/uv.lock
@@ -569,6 +569,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.5,<4.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pyarrow", marker = "extra == 'io'", specifier = ">=21.0.0" },
+    { name = "pyarrow", extras = ["parquet"], marker = "extra == 'io'" },
     { name = "pydantic", specifier = ">=2.10.6,<3.0.0" },
 ]
 provides-extras = ["io"]

--- a/uv.lock
+++ b/uv.lock
@@ -529,6 +529,11 @@ dependencies = [
     { name = "pydantic" },
 ]
 
+[package.optional-dependencies]
+io = [
+    { name = "pyarrow" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -563,8 +568,10 @@ requires-dist = [
     { name = "healpy", specifier = ">=1.18.1,<2.0.0" },
     { name = "networkx", specifier = ">=3.5,<4.0" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "pyarrow", marker = "extra == 'io'", specifier = ">=21.0.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3.0.0" },
 ]
+provides-extras = ["io"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -645,6 +652,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc", size = 1133487, upload-time = "2025-07-18T00:57:31.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/dc/80564a3071a57c20b7c32575e4a0120e8a330ef487c319b122942d665960/pyarrow-21.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b", size = 31243234, upload-time = "2025-07-18T00:55:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/cc/3b51cb2db26fe535d14f74cab4c79b191ed9a8cd4cbba45e2379b5ca2746/pyarrow-21.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10", size = 32714370, upload-time = "2025-07-18T00:55:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/a4431f36d5ad7d83b87146f515c063e4d07ef0b7240876ddb885e6b44f2e/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e", size = 41135424, upload-time = "2025-07-18T00:55:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/74/dc/035d54638fc5d2971cbf1e987ccd45f1091c83bcf747281cf6cc25e72c88/pyarrow-21.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569", size = 42823810, upload-time = "2025-07-18T00:55:16.301Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3b/89fced102448a9e3e0d4dded1f37fa3ce4700f02cdb8665457fcc8015f5b/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e", size = 43391538, upload-time = "2025-07-18T00:55:23.82Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/ea7f1bd08978d39debd3b23611c293f64a642557e8141c80635d501e6d53/pyarrow-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c", size = 45120056, upload-time = "2025-07-18T00:55:28.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0b/77ea0600009842b30ceebc3337639a7380cd946061b620ac1a2f3cb541e2/pyarrow-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6", size = 26220568, upload-time = "2025-07-18T00:55:32.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d4/d4f817b21aacc30195cf6a46ba041dd1be827efa4a623cc8bf39a1c2a0c0/pyarrow-21.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3a302f0e0963db37e0a24a70c56cf91a4faa0bca51c23812279ca2e23481fccd", size = 31160305, upload-time = "2025-07-18T00:55:35.373Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9c/dcd38ce6e4b4d9a19e1d36914cb8e2b1da4e6003dd075474c4cfcdfe0601/pyarrow-21.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:b6b27cf01e243871390474a211a7922bfbe3bda21e39bc9160daf0da3fe48876", size = 32684264, upload-time = "2025-07-18T00:55:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/2a2d9f8d7a59b639523454bec12dba35ae3d0a07d8ab529dc0809f74b23c/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e72a8ec6b868e258a2cd2672d91f2860ad532d590ce94cdf7d5e7ec674ccf03d", size = 41108099, upload-time = "2025-07-18T00:55:42.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/90/2660332eeb31303c13b653ea566a9918484b6e4d6b9d2d46879a33ab0622/pyarrow-21.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e", size = 42829529, upload-time = "2025-07-18T00:55:47.069Z" },
+    { url = "https://files.pythonhosted.org/packages/33/27/1a93a25c92717f6aa0fca06eb4700860577d016cd3ae51aad0e0488ac899/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82", size = 43367883, upload-time = "2025-07-18T00:55:53.069Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d9/4d09d919f35d599bc05c6950095e358c3e15148ead26292dfca1fb659b0c/pyarrow-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623", size = 45133802, upload-time = "2025-07-18T00:55:57.714Z" },
+    { url = "https://files.pythonhosted.org/packages/71/30/f3795b6e192c3ab881325ffe172e526499eb3780e306a15103a2764916a2/pyarrow-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf56ec8b0a5c8c9d7021d6fd754e688104f9ebebf1bf4449613c9531f5346a18", size = 26203175, upload-time = "2025-07-18T00:56:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ca/c7eaa8e62db8fb37ce942b1ea0c6d7abfe3786ca193957afa25e71b81b66/pyarrow-21.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e99310a4ebd4479bcd1964dff9e14af33746300cb014aa4a3781738ac63baf4a", size = 31154306, upload-time = "2025-07-18T00:56:04.42Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e8/e87d9e3b2489302b3a1aea709aaca4b781c5252fcb812a17ab6275a9a484/pyarrow-21.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d2fe8e7f3ce329a71b7ddd7498b3cfac0eeb200c2789bd840234f0dc271a8efe", size = 32680622, upload-time = "2025-07-18T00:56:07.505Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/79095d73a742aa0aba370c7942b1b655f598069489ab387fe47261a849e1/pyarrow-21.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f522e5709379d72fb3da7785aa489ff0bb87448a9dc5a75f45763a795a089ebd", size = 41104094, upload-time = "2025-07-18T00:56:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/89/4b/7782438b551dbb0468892a276b8c789b8bbdb25ea5c5eb27faadd753e037/pyarrow-21.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:69cbbdf0631396e9925e048cfa5bce4e8c3d3b41562bbd70c685a8eb53a91e61", size = 42825576, upload-time = "2025-07-18T00:56:15.569Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/62/0f29de6e0a1e33518dec92c65be0351d32d7ca351e51ec5f4f837a9aab91/pyarrow-21.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:731c7022587006b755d0bdb27626a1a3bb004bb56b11fb30d98b6c1b4718579d", size = 43368342, upload-time = "2025-07-18T00:56:19.531Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c7/0fa1f3f29cf75f339768cc698c8ad4ddd2481c1742e9741459911c9ac477/pyarrow-21.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc56bc708f2d8ac71bd1dcb927e458c93cec10b98eb4120206a4091db7b67b99", size = 45131218, upload-time = "2025-07-18T00:56:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/01/63/581f2076465e67b23bc5a37d4a2abff8362d389d29d8105832e82c9c811c/pyarrow-21.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:186aa00bca62139f75b7de8420f745f2af12941595bbbfa7ed3870ff63e25636", size = 26087551, upload-time = "2025-07-18T00:56:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/357d0d9648bb8241ee7348e564f2479d206ebe6e1c47ac5027c2e31ecd39/pyarrow-21.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:a7a102574faa3f421141a64c10216e078df467ab9576684d5cd696952546e2da", size = 31290064, upload-time = "2025-07-18T00:56:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8a/5685d62a990e4cac2043fc76b4661bf38d06efed55cf45a334b455bd2759/pyarrow-21.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:1e005378c4a2c6db3ada3ad4c217b381f6c886f0a80d6a316fe586b90f77efd7", size = 32727837, upload-time = "2025-07-18T00:56:33.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/de/c0828ee09525c2bafefd3e736a248ebe764d07d0fd762d4f0929dbc516c9/pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:65f8e85f79031449ec8706b74504a316805217b35b6099155dd7e227eef0d4b6", size = 41014158, upload-time = "2025-07-18T00:56:37.528Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/26/a2865c420c50b7a3748320b614f3484bfcde8347b2639b2b903b21ce6a72/pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:3a81486adc665c7eb1a2bde0224cfca6ceaba344a82a971ef059678417880eb8", size = 42667885, upload-time = "2025-07-18T00:56:41.483Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f9/4ee798dc902533159250fb4321267730bc0a107d8c6889e07c3add4fe3a5/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fc0d2f88b81dcf3ccf9a6ae17f89183762c8a94a5bdcfa09e05cfe413acf0503", size = 43276625, upload-time = "2025-07-18T00:56:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/da/e02544d6997037a4b0d22d8e5f66bc9315c3671371a8b18c79ade1cefe14/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6299449adf89df38537837487a4f8d3bd91ec94354fdd2a7d30bc11c48ef6e79", size = 44951890, upload-time = "2025-07-18T00:56:52.568Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4e/519c1bc1876625fe6b71e9a28287c43ec2f20f73c658b9ae1d485c0c206e/pyarrow-21.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:222c39e2c70113543982c6b34f3077962b44fca38c0bd9e68bb6781534425c10", size = 26371006, upload-time = "2025-07-18T00:56:56.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a basic parquet writer for certain data types. It will be used primarily to produce particle datasets for visualization purposes.
