### PR TITLE
Structure Collections for Lightcones

### DIFF
--- a/changes/103.bugfix.rst
+++ b/changes/103.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that caused structure collections to not open correctly if the individual datasets were lightcone datasets.

--- a/src/opencosmo/collection/lightcone/lightcone.py
+++ b/src/opencosmo/collection/lightcone/lightcone.py
@@ -98,6 +98,9 @@ def with_redshift_column(dataset: Dataset):
     elif "redshift_true" in dataset.columns:
         z_col = 1 * oc.col("redshift_true")
         return dataset.with_new_columns(redshift=z_col)
+    raise ValueError(
+        "Unable to find a redshift or scale factor column for this lightcone dataset"
+    )
 
 
 class Lightcone(dict):

--- a/src/opencosmo/collection/structure/io.py
+++ b/src/opencosmo/collection/structure/io.py
@@ -135,6 +135,9 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
         len(link_sources["halo_properties"]) > 1
         or len(link_sources["galaxy_properties"]) > 1
     ):
+        raise NotImplementedError(
+            "Opening structure collections that span multiple redshifts is not currently supported"
+        )
         # Potentially a lightcone structure collection
         collections = {}
         sources_by_step, targets_by_step = __sort_by_step(link_sources, link_targets)
@@ -165,10 +168,12 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
         galaxy_properties_target = link_sources["galaxy_properties"][0]
 
     input_link_targets = {}
-    for source_type, targets in link_targets.items():
-        if any(len(ts) > 1 for ts in targets.values()):
+    for source_type, source_targets in link_targets.items():
+        if any(len(ts) > 1 for ts in source_targets.values()):
             raise ValueError("Found more than one linked file of a given type!")
-        input_link_targets[source_type] = {key: t[0] for key, t in targets.items()}
+        input_link_targets[source_type] = {
+            key: t[0] for key, t in source_targets.items()
+        }
 
     return __build_structure_collection(
         halo_properties_target,
@@ -179,8 +184,8 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
 
 
 def __sort_by_step(link_sources: dict[str, list[io.io.OpenTarget]], link_targets):
-    sources_by_step: dict[str, io.io.OpenTarget] = defaultdict(dict)
-    targets_by_step: dict[str, dict[str, d.Dataset]] = defaultdict(
+    sources_by_step: dict[int, dict[str, io.io.OpenTarget]] = defaultdict(dict)
+    targets_by_step: dict[int, dict[str, dict[str, d.Dataset]]] = defaultdict(
         lambda: defaultdict(dict)
     )
     for source_name, sources in link_sources.items():

--- a/src/opencosmo/collection/structure/io.py
+++ b/src/opencosmo/collection/structure/io.py
@@ -83,7 +83,8 @@ def get_linked_datasets(
         else:
             targets.update({dtype: io.io.OpenTarget(pointer, header)})
     datasets = {
-        dtype: io.io.open_single_dataset(target) for dtype, target in targets.items()
+        dtype: io.io.open_single_dataset(target, bypass_lightcone=True)
+        for dtype, target in targets.items()
     }
     return datasets
 
@@ -109,7 +110,7 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
         elif target.data_type == "galaxy_properties":
             link_sources["galaxy_properties"].append(target)
         elif target.data_type.startswith("halo"):
-            dataset = io.io.open_single_dataset(target)
+            dataset = io.io.open_single_dataset(target, bypass_lightcone=True)
             name = target.group.name.split("/")[-1]
             if not name:
                 name = target.data_type
@@ -117,7 +118,7 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
                 name = name[16:]
             link_targets["halo_targets"][name] = dataset
         elif target.data_type.startswith("galaxy"):
-            dataset = io.io.open_single_dataset(target)
+            dataset = io.io.open_single_dataset(target, bypass_lightcone=True)
             name = target.group.name.split("/")[-1]
             if not name:
                 name = target.data_type
@@ -136,7 +137,9 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
             link_sources["galaxy_properties"][0].header,
         )
 
-        source_dataset = io.io.open_single_dataset(link_sources["galaxy_properties"][0])
+        source_dataset = io.io.open_single_dataset(
+            link_sources["galaxy_properties"][0], bypass_lightcone=True
+        )
         if ignore_empty:
             new_index = make_index_with_linked_data(source_dataset.index, handlers)
             source_dataset = source_dataset.with_index(new_index)
@@ -157,7 +160,7 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
         and not link_targets["galaxy_targets"]
     ):
         galaxy_properties = io.io.open_single_dataset(
-            link_sources["galaxy_properties"][0]
+            link_sources["galaxy_properties"][0], bypass_lightcone=True
         )
         link_targets["halo_targets"]["galaxy_properties"] = galaxy_properties
 
@@ -167,7 +170,9 @@ def build_structure_collection(targets: list[io.io.OpenTarget], ignore_empty: bo
             list(link_targets["halo_targets"].keys()),
             link_sources["halo_properties"][0].header,
         )
-        source_dataset = io.io.open_single_dataset(link_sources["halo_properties"][0])
+        source_dataset = io.io.open_single_dataset(
+            link_sources["halo_properties"][0], bypass_lightcone=True
+        )
 
         if ignore_empty:
             new_index = make_index_with_linked_data(source_dataset.index, handlers)

--- a/src/opencosmo/dataset/dataset.py
+++ b/src/opencosmo/dataset/dataset.py
@@ -737,7 +737,6 @@ class Dataset:
         """
         if isinstance(descriptions, str):
             descriptions = {key: descriptions for key in new_columns.keys()}
-        print(descriptions)
         new_state = self.__state.with_new_columns(descriptions, **new_columns)
         return Dataset(self.__handler, self.__header, new_state, self.__tree)
 

--- a/src/opencosmo/dataset/state.py
+++ b/src/opencosmo/dataset/state.py
@@ -197,7 +197,6 @@ class DatasetState:
         new_im_handler = self.__im_handler
         derived_update = {}
         new_unit_handler = self.__unit_handler
-        print(new_columns)
         for name, new_col in new_columns.items():
             if name in column_names:
                 raise ValueError(f"Dataset already has column named {name}")

--- a/src/opencosmo/io/io.py
+++ b/src/opencosmo/io/io.py
@@ -233,7 +233,7 @@ def open(
     # For now the only way to open multiple files is with a StructureCollection
 
 
-def open_single_dataset(target: OpenTarget):
+def open_single_dataset(target: OpenTarget, bypass_lightcone: bool = False):
     header = target.header
     handle = target.group
 
@@ -290,7 +290,7 @@ def open_single_dataset(target: OpenTarget):
         tree=tree,
     )
 
-    if header.file.is_lightcone:
+    if header.file.is_lightcone and not bypass_lightcone:
         return collection.Lightcone({"data": dataset}, header.lightcone["z_range"])
 
     return dataset

--- a/src/opencosmo/io/io.py
+++ b/src/opencosmo/io/io.py
@@ -225,6 +225,7 @@ def open(
     targets = evaluate_load_conditions(targets, open_kwargs)
     if len(targets) > 1:
         collection_type = collection.get_collection_type(targets, file_types)
+        print(collection_type)
         return collection_type.open(targets, **open_kwargs)
 
     else:

--- a/src/opencosmo/io/io.py
+++ b/src/opencosmo/io/io.py
@@ -225,7 +225,6 @@ def open(
     targets = evaluate_load_conditions(targets, open_kwargs)
     if len(targets) > 1:
         collection_type = collection.get_collection_type(targets, file_types)
-        print(collection_type)
         return collection_type.open(targets, **open_kwargs)
 
     else:

--- a/test/test_lightcone.py
+++ b/test/test_lightcone.py
@@ -437,7 +437,12 @@ def test_write_single_lightcone(haloproperties_600_path, tmp_path):
     assert len(ds) == len(ds_written)
 
 
-def test_lightcone_structure_collection(structure_600):
+def test_lightcone_structure_collection_open(structure_600):
     c = oc.open(*structure_600)
+    assert isinstance(c, oc.StructureCollection)
+
+
+def test_lightcone_structure_collection_open_multiple(structure_600, structure_601):
+    c = oc.open(*structure_600, *structure_601)
     print(c)
-    assert False
+    assert isinstance(c, oc.StructureCollection)

--- a/test/test_lightcone.py
+++ b/test/test_lightcone.py
@@ -443,6 +443,5 @@ def test_lightcone_structure_collection_open(structure_600):
 
 
 def test_lightcone_structure_collection_open_multiple(structure_600, structure_601):
-    c = oc.open(*structure_600, *structure_601)
-    print(c)
-    assert isinstance(c, oc.StructureCollection)
+    with pytest.raises(NotImplementedError):
+        _ = oc.open(*structure_600, *structure_601)

--- a/test/test_lightcone.py
+++ b/test/test_lightcone.py
@@ -18,6 +18,21 @@ def haloproperties_601_path(lightcone_path):
     return lightcone_path / "step_601" / "haloproperties.hdf5"
 
 
+@pytest.fixture
+def all_files():
+    return ["haloparticles.hdf5", "haloproperties.hdf5", "sodpropertybins.hdf5"]
+
+
+@pytest.fixture
+def structure_600(lightcone_path, all_files):
+    return [lightcone_path / "step_600" / f for f in all_files]
+
+
+@pytest.fixture
+def structure_601(lightcone_path, all_files):
+    return [lightcone_path / "step_601" / f for f in all_files]
+
+
 def test_healpix_index(haloproperties_600_path):
     ds = oc.open(haloproperties_600_path)
     raw_data = ds.data
@@ -420,3 +435,9 @@ def test_write_single_lightcone(haloproperties_600_path, tmp_path):
     ds_written = oc.open(tmp_path / "temp.hdf5")
     assert isinstance(ds, oc.Lightcone)
     assert len(ds) == len(ds_written)
+
+
+def test_lightcone_structure_collection(structure_600):
+    c = oc.open(*structure_600)
+    print(c)
+    assert False


### PR DESCRIPTION
This fixes #103 for the case that we are working with a single redshift slice. 

This does NOT implemented structure collections for multiple lightcone redshift slices. These will be implemented at a later time. However the toolkit can now detect such cases and will raise a NotImplementedError.
