### PR TITLE
Caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13']
     defaults:
       run:
         shell: bash

--- a/changes/+76fb6505.feature.rst
+++ b/changes/+76fb6505.feature.rst
@@ -1,0 +1,1 @@
+Columns that are read from disk are now cached, ensuring that requesting data second time is always fast.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
   "h5py>=3.12.1,<4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opencosmo"
-version = "0.10.0a1"
+version = "1.0.0a1"
 description = "OpenCosmo Python Toolkit"
 authors = [
   { name = "Patrick Wells", email = "pwells@anl.gov" },
@@ -8,7 +8,7 @@ authors = [
 
 ]
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11"
 
 dependencies = [
   "h5py>=3.12.1,<4.0.0",

--- a/src/opencosmo/column/cache.py
+++ b/src/opencosmo/column/cache.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable, Optional
+from weakref import WeakValueDictionary, ref
+
+from opencosmo.index.protocols import DataIndex
+from opencosmo.index.take import take
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from opencosmo.index import DataIndex
+
+
+class ColumnCache:
+    """
+    A column cache is used to persist data that is read from an hdf5 file. Caches can get data in one of two ways:
+    1. They are explicitly given data that has been recently read from disk or
+    2. They take data from a previous cache
+
+
+    """
+
+    def __init__(
+        self,
+        columns: dict[str, np.ndarray],
+        derived_index: Optional[DataIndex] = None,
+        parent: Optional[ref[ColumnCache]] = None,
+    ):
+        self.__columns = columns
+        self.__derived_index = derived_index
+        self.__parent = parent
+
+    @classmethod
+    def empty(cls):
+        return ColumnCache({})
+
+    def __len__(self):
+        if not self.__columns and self.__derived_index is None:
+            return 0
+        elif self.__derived_index is not None:
+            return len(self.__derived_index)
+        else:
+            return len(next(iter(self.__columns.values())))
+
+    def add_data(self, data: dict[str, np.ndarray]):
+        lengths = set(len(d) for d in data.values())
+        if len(lengths) > 1:
+            raise ValueError(
+                "When adding data to the cache, all columns must be the same length"
+            )
+        elif (l := len(self)) > 0 and l != lengths.pop():
+            raise ValueError(
+                "When adding data to the cache, the columns must be the same length as the columns currently in the cache"
+            )
+
+        self.__columns = self.__columns | data
+
+    def has(self, column_name):
+        if column_name in self.__columns:
+            return True
+        if self.__parent is None:
+            return False
+        parent = self.__parent()
+        if parent is None:
+            return False
+        return parent.has(column_name)
+
+    def request(self, column_name: str, index: DataIndex):
+        if column_name in self.__columns:
+            return index.get_data(self.__columns[column_name])
+        elif self.__parent is None:
+            return None
+        parent = self.__parent()
+        if parent is None or not parent.has(column_name):
+            return None
+        assert self.__derived_index is not None
+        new_index = take(self.__derived_index, index)
+        return parent.take(new_index)
+
+    def take(self, index: DataIndex):
+        if index.range()[1] > len(self):
+            raise ValueError(
+                "Tried to take more elements than the length of the cache!"
+            )
+        return ColumnCache({}, index, ref(self))
+
+    def get_columns(self, columns: Iterable[str]):
+        columns = set(columns)
+        output = {}
+        for column in columns:
+            if (existing_column := self.__columns.get(column)) is not None:
+                output[column] = existing_column
+            elif (derived_column := self.__get_derived_column(column)) is not None:
+                output[column] = derived_column
+        return output
+
+    def __get_derived_column(self, column_name: str):
+        if self.__derived_index is None:
+            return None
+        assert self.__parent is not None
+        parent = self.__parent()
+        if parent is None:
+            return None
+        result = parent.request(column_name, self.__derived_index)
+        if result is not None:
+            self.__columns[column_name] = result
+        return result

--- a/src/opencosmo/column/cache.py
+++ b/src/opencosmo/column/cache.py
@@ -101,6 +101,8 @@ class ColumnCache:
         return data | parent.request(column_names, new_index)
 
     def take(self, index: DataIndex):
+        if len(self) == 0:
+            return ColumnCache.empty()
         if index.range()[1] > len(self):
             raise ValueError(
                 "Tried to take more elements than the length of the cache!"

--- a/src/opencosmo/column/cache.py
+++ b/src/opencosmo/column/cache.py
@@ -76,7 +76,7 @@ class ColumnCache:
             return None
         assert self.__derived_index is not None
         new_index = take(self.__derived_index, index)
-        return parent.take(new_index)
+        return parent.request(column_name, new_index)
 
     def take(self, index: DataIndex):
         if index.range()[1] > len(self):

--- a/src/opencosmo/column/cache.py
+++ b/src/opencosmo/column/cache.py
@@ -156,10 +156,18 @@ class ColumnCache:
         file.
 
         """
+        if not self.registered_columns.issuperset(data.keys()):
+            raise ValueError(
+                "Tried to add columns to the cache that are not registered to it!"
+            )
         check_length(self, data)
         self.__cached_data = self.__cached_data | data
 
     def with_data(self, data: dict[str, np.ndarray]):
+        if not self.registered_columns.issuperset(data.keys()):
+            raise ValueError(
+                "Tried to add columns to the cache that are not registered to it!"
+            )
         check_length(self, data)
         new_cached_data = self.__cached_data | data
         new_cache = ColumnCache(
@@ -210,6 +218,11 @@ class ColumnCache:
 
     def get_columns(self, columns: Iterable[str]):
         columns = set(columns)
+        if not columns.issubset(self.registered_columns):
+            raise ValueError(
+                "Tried to get columns that are not registered to this cache!"
+            )
+
         columns_in_cache = columns.intersection(self.__cached_data.keys())
         missing_columns = columns - columns_in_cache
         output = {c: self.__cached_data[c] for c in columns_in_cache}

--- a/src/opencosmo/column/cache.py
+++ b/src/opencosmo/column/cache.py
@@ -67,7 +67,6 @@ class ColumnCache:
         if children is None:
             children = []
         self.__children = children
-        self.__children = children
         self.__finalizer = None
 
         if parent is not None and (p := parent()) is not None:

--- a/src/opencosmo/dataset/dataset.py
+++ b/src/opencosmo/dataset/dataset.py
@@ -48,7 +48,6 @@ class Dataset:
         self.__header = header
         self.__state = state
         self.__tree = tree
-        self.__cached_data: Optional[OpenCosmoData] = None
 
     def __repr__(self):
         """
@@ -199,17 +198,7 @@ class Dataset:
         """
         Return the data in the dataset in astropy format. The value of this
         attribute is equivalent to the return value of
-        :code:`Dataset.get_data("astropy")`. However data retrieved via this
-        attribute will be cached, meaning further calls to
-        :py:attr:`Dataset.data <opencosmo.Dataset.data>` should be instantaneous.
-
-        However there is one caveat. If you modify the table, those modifications will
-        persist if you later request the data again with this attribute. Calls to
-        :py:meth:`Dataset.get_data <opencosmo.Dataset.get_data>` will be unaffected, and
-        datasets generated from this dataset will not contain the modifications. If you
-        plan to modify the data in this table, you should use
-        :py:meth:`Dataset.with_new_columns <opencosmo.Dataset.with_new_columns>`.
-
+        :code:`Dataset.get_data("astropy")`.
 
         Returns
         -------
@@ -219,9 +208,7 @@ class Dataset:
         """
         # should rename this, dataset.data can get confusing
         # Also the point is that there's MORE data than just the table
-        if self.__cached_data is None:
-            self.__cached_data = self.get_data("astropy")
-        return self.__cached_data.copy()
+        return self.get_data("astropy")
 
     def get_metadata(self, columns: list[str] = []):
         return self.__state.get_metadata(columns)

--- a/src/opencosmo/dataset/handler.py
+++ b/src/opencosmo/dataset/handler.py
@@ -144,16 +144,19 @@ class Hdf5Handler:
         """ """
         if self.__group is None:
             raise ValueError("This file has already been closed")
-        data = self.__cache.get_columns(columns)
-        remaining = set(columns).difference(data.keys())
-        additional = {}
+        cached_data = self.__cache.get_columns(columns)
+        remaining = set(columns).difference(cached_data.keys())
+        new_data = {}
 
         for colname in remaining:
-            additional[colname] = self.__index.get_data(self.__group[colname])
-        if additional:
-            self.__cache.add_data(additional)
+            new_data[colname] = self.__index.get_data(self.__group[colname])
+        if new_data:
+            self.__cache.add_data(new_data)
 
-        return data | additional
+        data = new_data | cached_data
+
+        # Ensure order is preserved
+        return {name: data[name] for name in columns}
 
     def get_metadata(self, columns: Iterable[str]) -> Optional[dict[str, np.ndarray]]:
         if self.__metadata_group is None:

--- a/src/opencosmo/dataset/handler.py
+++ b/src/opencosmo/dataset/handler.py
@@ -66,9 +66,10 @@ class Hdf5Handler:
         self.__registered_column_groups[id(state)] = set(state.columns)
 
     def deregister(self, state_id: int):
+        # print(self.__registered_column_groups)
         columns = self.__registered_column_groups.pop(state_id)
         remaining_columns = set().union(*list(self.__registered_column_groups.values()))
-        to_drop = columns - remaining_columns
+        to_drop = columns.difference(remaining_columns)
         self.__cache.drop(to_drop)
 
     def take(self, other: DataIndex, sorted: Optional[np.ndarray] = None):

--- a/src/opencosmo/dataset/handler.py
+++ b/src/opencosmo/dataset/handler.py
@@ -63,14 +63,10 @@ class Hdf5Handler:
         return Hdf5Handler(group, index, ColumnCache.empty(), metadata_group, {})
 
     def register(self, state: DatasetState):
-        self.__registered_column_groups[id(state)] = set(state.columns)
+        self.__cache.register_column_group(id(state), set(state.columns))
 
     def deregister(self, state_id: int):
-        # print(self.__registered_column_groups)
-        columns = self.__registered_column_groups.pop(state_id)
-        remaining_columns = set().union(*list(self.__registered_column_groups.values()))
-        to_drop = columns.difference(remaining_columns)
-        self.__cache.drop(to_drop)
+        self.__cache.deregister_column_group(state_id)
 
     def take(self, other: DataIndex, sorted: Optional[np.ndarray] = None):
         if len(other) == 0:

--- a/src/opencosmo/dataset/handler.py
+++ b/src/opencosmo/dataset/handler.py
@@ -151,7 +151,7 @@ class Hdf5Handler:
         for colname in remaining:
             new_data[colname] = self.__index.get_data(self.__group[colname])
         if new_data:
-            self.__cache.add_data(new_data)
+            self.__cache = self.__cache.with_data(new_data)
 
         data = new_data | cached_data
 

--- a/src/opencosmo/dataset/handler.py
+++ b/src/opencosmo/dataset/handler.py
@@ -32,13 +32,11 @@ class Hdf5Handler:
         index: DataIndex,
         cache: ColumnCache,
         metadata_group: Optional[h5py.Group],
-        registered_column_groups: dict[int, set[str]],
     ):
         self.__index = index
         self.__group = group
         self.__cache = cache
         self.__metadata_group = metadata_group
-        self.__registered_column_groups = registered_column_groups
 
     @classmethod
     def from_group(
@@ -60,7 +58,7 @@ class Hdf5Handler:
         if metadata_group is not None:
             colnames = chain(colnames, metadata_group.keys())
 
-        return Hdf5Handler(group, index, ColumnCache.empty(), metadata_group, {})
+        return Hdf5Handler(group, index, ColumnCache.empty(), metadata_group)
 
     def register(self, state: DatasetState):
         self.__cache.register_column_group(id(state), set(state.columns))
@@ -71,7 +69,7 @@ class Hdf5Handler:
     def take(self, other: DataIndex, sorted: Optional[np.ndarray] = None):
         if len(other) == 0:
             return Hdf5Handler(
-                self.__group, other, ColumnCache.empty(), self.__metadata_group, {}
+                self.__group, other, ColumnCache.empty(), self.__metadata_group
             )
 
         if sorted is not None:
@@ -79,9 +77,7 @@ class Hdf5Handler:
 
         new_index = take(self.__index, other)
         new_cache = self.__cache.take(other)
-        return Hdf5Handler(
-            self.__group, new_index, new_cache, self.__metadata_group, {}
-        )
+        return Hdf5Handler(self.__group, new_index, new_cache, self.__metadata_group)
 
     def __take_sorted(self, other: DataIndex, sorted: np.ndarray):
         if len(sorted) != len(self.__index):
@@ -94,9 +90,7 @@ class Hdf5Handler:
         new_cache_index = SimpleIndex(new_indices)
         new_cache = self.__cache.take(new_cache_index)
 
-        return Hdf5Handler(
-            self.__group, new_index, new_cache, self.__metadata_group, {}
-        )
+        return Hdf5Handler(self.__group, new_index, new_cache, self.__metadata_group)
 
     @property
     def data(self):

--- a/src/opencosmo/dataset/state.py
+++ b/src/opencosmo/dataset/state.py
@@ -157,7 +157,7 @@ class DatasetState:
         raw_data = self.__raw_data_handler.get_data(raw_columns)
         data = data | self.__unit_handler.apply_units(raw_data, unit_kwargs)
 
-        output = QTable(data)
+        output = QTable(data, copy=False)
 
         data_columns = set(output.columns)
         raw_index_array = self.__raw_data_handler.index.into_array()

--- a/src/opencosmo/dataset/state.py
+++ b/src/opencosmo/dataset/state.py
@@ -362,7 +362,9 @@ class DatasetState:
                 f"Tried to select columns that are not in this dataset: {missing}"
             )
 
-        return self.__rebuild(columns=columns)
+        new_handler = self.__raw_data_handler.select(columns)
+
+        return self.__rebuild(columns=columns, raw_data_handler=new_handler)
 
     def sort_by(self, column_name: str, invert: bool):
         if column_name not in self.columns:

--- a/src/opencosmo/dataset/state.py
+++ b/src/opencosmo/dataset/state.py
@@ -58,7 +58,7 @@ class DatasetState:
         self.__columns = columns
         self.__region = region
         self.__sort_by = sort_by
-        self.__raw_data_handler.register(self)
+        self.__raw_data_handler.register(self, self.__derived_columns)
         finalize(self, deregister_state, id(self), self.__raw_data_handler)
 
     def __rebuild(self, **updates):

--- a/src/opencosmo/dataset/state.py
+++ b/src/opencosmo/dataset/state.py
@@ -198,7 +198,7 @@ class DatasetState:
         header = self.__header.with_region(self.__region)
         raw_columns = self.__columns.intersection(self.__raw_data_handler.columns)
 
-        schema = self.__raw_data_handler.prep_write(raw_columns, header)
+        schema = self.__raw_data_handler.make_schema(raw_columns, header)
         derived_names = set(self.__derived_columns.keys()).intersection(self.columns)
         derived_data = (
             self.select(derived_names)

--- a/src/opencosmo/index/chunked.py
+++ b/src/opencosmo/index/chunked.py
@@ -14,32 +14,6 @@ if TYPE_CHECKING:
     from opencosmo.index.protocols import DataIndex
 
 
-def pack(start: np.ndarray, size: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Combine adjacent chunks into a single chunk.
-    """
-
-    # Calculate the end of each chunk
-    end = start + size
-
-    # Determine where a new chunk should start (i.e., not adjacent to previous)
-    # We prepend True for the first chunk to always start a group
-    new_group = np.ones(len(start), dtype=bool)
-    new_group[1:] = start[1:] != end[:-1]
-
-    # Assign a group ID for each segment
-    group_ids = np.cumsum(new_group)
-
-    # Combine chunks by group
-    combined_start = np.zeros(group_ids[-1], dtype=start.dtype)
-    combined_size = np.zeros_like(combined_start)
-
-    np.add.at(combined_start, group_ids - 1, np.where(new_group, start, 0))
-    np.add.at(combined_size, group_ids - 1, size)
-
-    return combined_start, combined_size
-
-
 class ChunkedIndex:
     def __init__(self, starts: np.ndarray, sizes: np.ndarray) -> None:
         """

--- a/src/opencosmo/index/get.py
+++ b/src/opencosmo/index/get.py
@@ -44,7 +44,7 @@ def get_data_chunked(
         if isinstance(data, h5py.Dataset):
             data.read_direct(storage, source_slice, dest_slice)
         else:
-            storage[dest_slice] = source_slice
+            storage[dest_slice] = data[source_slice]
 
         running_index += size
     return storage

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from opencosmo.column.cache import ColumnCache
+from opencosmo.index import SimpleIndex
+
+
+def test_cache_take():
+    data = {}
+    for name in "abcdefg":
+        data[name] = np.random.randint(0, 1000, 10_000)
+    cache = ColumnCache.empty()
+    cache.add_data(data)
+
+    indices2 = np.sort(np.random.choice(10_000, 100, replace=False))
+    index2 = SimpleIndex(indices2)
+
+    cache2 = cache.take(index2)
+    cached_data = cache2.get_columns("abcdefg")
+    for colname, column in cached_data.items():
+        assert np.all(column == data[colname][indices2])

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -52,14 +52,42 @@ def test_cache_passthrough_delete():
     indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
     index2 = SimpleIndex(indices2)
     cache2 = cache.take(index2)
+    _ = cache2.get_columns("abcdefg")
 
     indices3 = np.sort(np.random.choice(1000, 100, replace=False))
     index3 = SimpleIndex(indices3)
     cache3 = cache2.take(index3)
 
+    assert set(cache3._ColumnCache__columns.keys()) == set()
     del cache2
-
+    assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")
     cached_data = cache3.get_columns("abcdefg")
+
     for colname, column in cached_data.items():
         assert np.all(column == data[colname][indices2[indices3]])
-    assert len(cache3._ColumnCache__columns.keys()) == 0
+
+
+def test_cache_passthrough_twice_delete():
+    data = {}
+    for name in "abcdefg":
+        data[name] = np.random.randint(0, 1000, 10_000)
+    cache = ColumnCache.empty()
+    cache.add_data(data)
+
+    indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
+    index2 = SimpleIndex(indices2)
+    cache2 = cache.take(index2)
+
+    indices3 = np.sort(np.random.choice(1000, 100, replace=False))
+    index3 = SimpleIndex(indices3)
+    cache3 = cache2.take(index3)
+
+    assert set(cache2._ColumnCache__columns.keys()) == set()
+    del cache
+    assert set(cache2._ColumnCache__columns.keys()) == set("abcdefg")
+
+    cached_data = cache3.get_columns("abcdefg")
+
+    for colname, column in cached_data.items():
+        assert np.all(column == data[colname][indices2[indices3]])
+    assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -40,3 +40,26 @@ def test_cache_passthrough():
         assert np.all(column == data[colname][indices2[indices3]])
     assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")
     assert len(cache2._ColumnCache__columns) == 0
+
+
+def test_cache_passthrough_delete():
+    data = {}
+    for name in "abcdefg":
+        data[name] = np.random.randint(0, 1000, 10_000)
+    cache = ColumnCache.empty()
+    cache.add_data(data)
+
+    indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
+    index2 = SimpleIndex(indices2)
+    cache2 = cache.take(index2)
+
+    indices3 = np.sort(np.random.choice(1000, 100, replace=False))
+    index3 = SimpleIndex(indices3)
+    cache3 = cache2.take(index3)
+
+    del cache2
+
+    cached_data = cache3.get_columns("abcdefg")
+    for colname, column in cached_data.items():
+        assert np.all(column == data[colname][indices2[indices3]])
+    assert len(cache3._ColumnCache__columns.keys()) == 0

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -18,3 +18,25 @@ def test_cache_take():
     cached_data = cache2.get_columns("abcdefg")
     for colname, column in cached_data.items():
         assert np.all(column == data[colname][indices2])
+
+
+def test_cache_passthrough():
+    data = {}
+    for name in "abcdefg":
+        data[name] = np.random.randint(0, 1000, 10_000)
+    cache = ColumnCache.empty()
+    cache.add_data(data)
+
+    indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
+    index2 = SimpleIndex(indices2)
+    cache2 = cache.take(index2)
+
+    indices3 = np.sort(np.random.choice(1000, 100, replace=False))
+    index3 = SimpleIndex(indices3)
+    cache3 = cache2.take(index3)
+
+    cached_data = cache3.get_columns("abcdefg")
+    for colname, column in cached_data.items():
+        assert np.all(column == data[colname][indices2[indices3]])
+    assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")
+    assert len(cache2._ColumnCache__columns) == 0

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -16,6 +16,7 @@ def test_cache_take():
     index2 = SimpleIndex(indices2)
 
     cache2 = cache.take(index2)
+    cache2.register_column_group(0, set("abcdefg"))
     cached_data = cache2.get_columns("abcdefg")
     for colname, column in cached_data.items():
         assert np.all(column == data[colname][indices2])
@@ -32,10 +33,12 @@ def test_cache_passthrough():
     indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
     index2 = SimpleIndex(indices2)
     cache2 = cache.take(index2)
+    cache2.register_column_group(0, set("abcdefg"))
 
     indices3 = np.sort(np.random.choice(1000, 100, replace=False))
     index3 = SimpleIndex(indices3)
     cache3 = cache2.take(index3)
+    cache3.register_column_group(0, set("abcdefg"))
 
     cached_data = cache3.get_columns("abcdefg")
     for colname, column in cached_data.items():

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -38,8 +38,8 @@ def test_cache_passthrough():
     cached_data = cache3.get_columns("abcdefg")
     for colname, column in cached_data.items():
         assert np.all(column == data[colname][indices2[indices3]])
-    assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")
-    assert len(cache2._ColumnCache__columns) == 0
+    assert set(cache3.columns) == set("abcdefg")
+    assert len(cache2.columns) == 0
 
 
 def test_cache_passthrough_delete():
@@ -58,9 +58,9 @@ def test_cache_passthrough_delete():
     index3 = SimpleIndex(indices3)
     cache3 = cache2.take(index3)
 
-    assert set(cache3._ColumnCache__columns.keys()) == set()
+    assert set(cache3.columns) == set()
     del cache2
-    assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")
+    assert set(cache3.columns) == set("abcdefg")
     cached_data = cache3.get_columns("abcdefg")
 
     for colname, column in cached_data.items():
@@ -82,12 +82,12 @@ def test_cache_passthrough_twice_delete():
     index3 = SimpleIndex(indices3)
     cache3 = cache2.take(index3)
 
-    assert set(cache2._ColumnCache__columns.keys()) == set()
+    assert set(cache2.columns) == set()
     del cache
-    assert set(cache2._ColumnCache__columns.keys()) == set("abcdefg")
+    assert set(cache2.columns) == set("abcdefg")
 
     cached_data = cache3.get_columns("abcdefg")
 
     for colname, column in cached_data.items():
         assert np.all(column == data[colname][indices2[indices3]])
-    assert set(cache3._ColumnCache__columns.keys()) == set("abcdefg")
+    assert set(cache3.columns) == set("abcdefg")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -9,6 +9,7 @@ def test_cache_take():
     for name in "abcdefg":
         data[name] = np.random.randint(0, 1000, 10_000)
     cache = ColumnCache.empty()
+    cache.register_column_group(0, set("abcdefg"))
     cache.add_data(data)
 
     indices2 = np.sort(np.random.choice(10_000, 100, replace=False))
@@ -25,6 +26,7 @@ def test_cache_passthrough():
     for name in "abcdefg":
         data[name] = np.random.randint(0, 1000, 10_000)
     cache = ColumnCache.empty()
+    cache.register_column_group(0, set("abcdefg"))
     cache.add_data(data)
 
     indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
@@ -47,16 +49,19 @@ def test_cache_passthrough_delete():
     for name in "abcdefg":
         data[name] = np.random.randint(0, 1000, 10_000)
     cache = ColumnCache.empty()
+    cache.register_column_group(0, set("abcdefg"))
     cache.add_data(data)
 
     indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
     index2 = SimpleIndex(indices2)
     cache2 = cache.take(index2)
+    cache2.register_column_group(0, set("abcdefg"))
     _ = cache2.get_columns("abcdefg")
 
     indices3 = np.sort(np.random.choice(1000, 100, replace=False))
     index3 = SimpleIndex(indices3)
     cache3 = cache2.take(index3)
+    cache3.register_column_group(0, set("abcdefg"))
 
     assert set(cache3.columns) == set()
     del cache2
@@ -72,15 +77,18 @@ def test_cache_passthrough_twice_delete():
     for name in "abcdefg":
         data[name] = np.random.randint(0, 1000, 10_000)
     cache = ColumnCache.empty()
+    cache.register_column_group(0, set("abcdefg"))
     cache.add_data(data)
 
     indices2 = np.sort(np.random.choice(10_000, 1000, replace=False))
     index2 = SimpleIndex(indices2)
     cache2 = cache.take(index2)
+    cache2.register_column_group(0, set("abcdefg"))
 
     indices3 = np.sort(np.random.choice(1000, 100, replace=False))
     index3 = SimpleIndex(indices3)
     cache3 = cache2.take(index3)
+    cache3.register_column_group(0, set("abcdefg"))
 
     assert set(cache2.columns) == set()
     del cache

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,4 +1,5 @@
 import os
+from time import sleep
 
 import astropy.units as u
 import numpy as np
@@ -477,6 +478,17 @@ def test_cache_select(input_path):
 
     del dataset
     assert cache.columns == set(columns)
+
+
+def test_cache_filter(input_path):
+    dataset = oc.open(input_path)
+    dataset = dataset.filter(oc.col("fof_halo_mass") > 1e14)
+
+    cache = dataset._Dataset__state._DatasetState__raw_data_handler._Hdf5Handler__cache
+
+    assert (
+        len(cache.columns) > 0 or cache._ColumnCache__parent() is not None
+    )  # just to be safe
 
 
 def test_write_after_sorted(input_path, tmp_path):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -442,6 +442,23 @@ def test_sort_rows(input_path):
         assert row["fof_halo_mass"].value == fof_masses[i]
 
 
+def test_cache(input_path):
+    from time import time
+
+    dataset = oc.open(input_path)
+
+    start1 = time()
+    data = dataset.get_data()
+    end1 = time()
+    dt1 = end1 - start1
+
+    start2 = time()
+    data2 = dataset.get_data()
+    end2 = time()
+    dt2 = end2 - start2
+    assert (dt2 / dt1) < 0.2
+
+
 def test_write_after_sorted(input_path, tmp_path):
     dataset = oc.open(input_path)
     dataset = dataset.sort_by("fof_halo_mass", invert=True)

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -473,19 +473,6 @@ def test_cache_select(input_path):
     assert cache.columns == set(columns)
 
 
-def test_cache_filter(input_path):
-    from weakref import ref
-
-    dataset = oc.open(input_path)
-    dataset = dataset.filter(oc.col("fof_halo_mass") > 1e13)
-    cache = dataset._Dataset__state._DatasetState__raw_data_handler._Hdf5Handler__cache
-    print(cache.columns)
-    assert False
-    # assert set(dataset.columns) == cache.columns
-
-    assert cache.columns == set(columns)
-
-
 def test_write_after_sorted(input_path, tmp_path):
     dataset = oc.open(input_path)
     dataset = dataset.sort_by("fof_halo_mass", invert=True)

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -473,6 +473,19 @@ def test_cache_select(input_path):
     assert cache.columns == set(columns)
 
 
+def test_cache_filter(input_path):
+    from weakref import ref
+
+    dataset = oc.open(input_path)
+    dataset = dataset.filter(oc.col("fof_halo_mass") > 1e13)
+    cache = dataset._Dataset__state._DatasetState__raw_data_handler._Hdf5Handler__cache
+    print(cache.columns)
+    assert False
+    # assert set(dataset.columns) == cache.columns
+
+    assert cache.columns == set(columns)
+
+
 def test_write_after_sorted(input_path, tmp_path):
     dataset = oc.open(input_path)
     dataset = dataset.sort_by("fof_halo_mass", invert=True)

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -459,6 +459,20 @@ def test_cache(input_path):
     assert (dt2 / dt1) < 0.2
 
 
+def test_cache_select(input_path):
+    from weakref import ref
+
+    dataset = oc.open(input_path)
+    data = dataset.get_data()
+    cache = dataset._Dataset__state._DatasetState__raw_data_handler._Hdf5Handler__cache
+    assert set(dataset.columns) == cache.columns
+    columns = np.random.choice(dataset.columns, 5, replace=False)
+    dataset2 = dataset.select(columns)
+
+    del dataset
+    assert cache.columns == set(columns)
+
+
 def test_write_after_sorted(input_path, tmp_path):
     dataset = oc.open(input_path)
     dataset = dataset.sort_by("fof_halo_mass", invert=True)

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,3 +1,5 @@
+import os
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -442,6 +444,10 @@ def test_sort_rows(input_path):
         assert row["fof_halo_mass"].value == fof_masses[i]
 
 
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
+
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test doesn't work in Github Actions.")
 def test_cache(input_path):
     from time import time
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -390,7 +390,7 @@ def test_write_after_filter(input_path, tmp_path):
         data = ds.data
 
     with oc.open(tmp_path / "haloproperties.hdf5") as new_ds:
-        filtered_data = new_ds.data
+        filtered_data = new_ds.get_data()
         assert np.all(data == filtered_data)
 
 

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import opencosmo as oc
@@ -59,6 +60,17 @@ def test_after_take_filter(halo_properties_path, tmp_path):
     write(tmp_path / "haloproperties.hdf5", ds)
     new_ds = oc.open(tmp_path / "haloproperties.hdf5")
     assert all(filtered_data == new_ds.data)
+
+
+def test_cache_write(halo_properties_path):
+    ds = oc.open(halo_properties_path).take(10000)
+    ds = ds.filter(col("sod_halo_mass") > 0)
+    filtered_data = ds.get_data()
+
+    schema = ds.make_schema()
+    data_children = schema.children["data"]
+    for child in data_children.values():
+        assert isinstance(child.source, np.ndarray)
 
 
 def test_after_take(halo_properties_path, tmp_path):


### PR DESCRIPTION
This PR introduces a cache for columns read from disk with the following properties.

- Columns read from disk are inserted into a in-memory cache that is attached to the dataset
- Derivative datasets inherit the cache and retain an index into the cached data that corresponds to their rows
- When a dataset is garbage collected, its cache data is pushed to its immediate children.
- When a dataset is garbage collected, the cache evicts any columns that were only being held for that dataset.

