### PR TITLE
Add error messages for two failure cases

### DIFF
--- a/changes/+97ce0b66.improvement.rst
+++ b/changes/+97ce0b66.improvement.rst
@@ -1,0 +1,1 @@
+Writing in an MPI context will now fail with an error if no rank has data to write

--- a/changes/+d8af6ed0.improvement.rst
+++ b/changes/+d8af6ed0.improvement.rst
@@ -1,0 +1,1 @@
+Opening multiple files will now fail with a clear error message if one or more of the files is not opencosmo-formatted.

--- a/src/opencosmo/collection/structure/structure.py
+++ b/src/opencosmo/collection/structure/structure.py
@@ -1260,7 +1260,6 @@ class StructureCollection:
     def make_schema(self) -> StructCollectionSchema:
         schema = StructCollectionSchema()
         source_name = self.__source.dtype
-        print("ASDF")
         datasets = self.__handler.resort(self.__source, self.__get_datasets())
 
         source_schema = self.__source.make_schema()

--- a/src/opencosmo/index/take.py
+++ b/src/opencosmo/index/take.py
@@ -136,6 +136,11 @@ def __take_chunked_from_chunked(from_: ChunkedIndex, by: ChunkedIndex):
     out_size = np.empty(max_out, dtype=np.int64)
     out_owner = np.empty(max_out, dtype=np.int64)
 
+    from_start = from_[0].astype(np.float64, copy=False)
+    from_size = from_[1].astype(np.float64, copy=False)
+    by_start = by[0].astype(np.float64, copy=False)
+    by_size = by[1].astype(np.float64, copy=False)
+
     n = resolve_spanning_numba(
         from_[0], from_[1], by[0], by[1], out_start, out_size, out_owner
     )

--- a/src/opencosmo/io/mpi.py
+++ b/src/opencosmo/io/mpi.py
@@ -71,6 +71,9 @@ def write_parallel(file: Path, file_schema: FileSchema):
         raise ValueError("One or more ranks recieved invalid schemas!")
 
     has_data = [i for i, state in enumerate(results) if state == CombineState.VALID]
+    if len(has_data) == 0:
+        raise ValueError("No ranks have any data to write!")
+
     group = comm.Get_group()
     new_group = group.Incl(has_data)
     new_comm = comm.Create(new_group)
@@ -183,8 +186,6 @@ def validate_headers(
     all_headers: Iterable[OpenCosmoHeader] = comm.allgather(header)
     all_headers = filter(lambda h: h is not None, all_headers)
     all_headers = list(map(lambda h: h.with_parameters(header_updates), all_headers))
-    print(header_updates)
-    print(all_headers)
     regions = set([h.file.region for h in all_headers])
     if len(regions) > 1:
         all_headers = [h.with_region(None) for h in all_headers]

--- a/src/opencosmo/io/schemas.py
+++ b/src/opencosmo/io/schemas.py
@@ -319,8 +319,7 @@ class DatasetSchema:
         if len(self.columns) == 0:
             raise ValueError("Datasets must have at least one column")
 
-        for group, columns in self.columns.items():
-            sizes = set(len(col) for col in columns.values())
+        sizes = set(len(col) for col in self.columns["data"].values())
 
         if len(sizes) == 1 and sizes.pop() == 0:
             raise ZeroLengthError()

--- a/test/test_diffsky.py
+++ b/test/test_diffsky.py
@@ -16,6 +16,11 @@ def core_path_475(diffsky_path):
     return diffsky_path / "lj_475.hdf5"
 
 
+@pytest.fixture
+def invalid_data_path(diffsky_path):
+    return diffsky_path / "random_data.hdf5"
+
+
 def test_comoving_to_physical(core_path_487):
     cores = oc.open(core_path_487, synth_cores=True).select(["redshift_true", "x"])
     data_physical = cores.with_units("physical").select(["redshift_true", "x"]).data
@@ -133,3 +138,8 @@ def test_add_mag_units_unitless(core_path_475, core_path_487):
 
     total_mag = -2.5 * np.log10(total_mag)
     assert np.all(data["lsst_total"] == total_mag)
+
+
+def test_open_bad_data(core_path_475, core_path_487, invalid_data_path):
+    with pytest.raises(ValueError, match=str(invalid_data_path)):
+        oc.open(core_path_475, core_path_487, invalid_data_path)


### PR DESCRIPTION
This PR adds meaningful error messages for two failure cases 

1. When someone attempts to open a file that is not an OpenCosmo file
2. When someone tries to write data in an MPI context but no ranks have any data
