### PR TITLE
Healpix Map Updates

### DIFF
--- a/changes/+31323023.improvement.rst
+++ b/changes/+31323023.improvement.rst
@@ -1,1 +1,1 @@
-You can now request HealpixMaps in Healpix format even when the map does not cover the full sky. Maps requested in this format will contain a `pixel` column.
+You can now request HealpixMaps in Healpix format even when the map does not cover the full sky. Maps requested in this format will be returned as masked numpy arrays.

--- a/changes/+31323023.improvement.rst
+++ b/changes/+31323023.improvement.rst
@@ -1,0 +1,1 @@
+You can now request HealpixMaps in Healpix format even when the map does not cover the full sky. Maps requested in this format will contain a `pixel` column.

--- a/changes/+91ec5e88.improvement.rst
+++ b/changes/+91ec5e88.improvement.rst
@@ -1,0 +1,1 @@
+Conversion to healsparse in :py:meth:`HealpixMap.get_data <opencosmo.HealpixMap.get_data` with `format = healsparse` has been rewritten, improving performance by roughly a factor of 5.

--- a/python/opencosmo/collection/lightcone/healpix_map.py
+++ b/python/opencosmo/collection/lightcone/healpix_map.py
@@ -33,6 +33,30 @@ if TYPE_CHECKING:
     from opencosmo.spatial import Region
 
 
+def make_healsparse_map(
+    pixels: np.ndarray,
+    values: np.ndarray,
+    nside: int,
+    nside_lr: int,
+) -> hsp.HealSparseMap:
+    sentinel = np.float32(hp.UNSEEN)
+    cov_map = hsp.HealSparseCoverage.make_empty(nside_lr, nside)
+    cov_pix = cov_map.cov_pixels(pixels)
+    unique_cov_pix = np.unique(cov_pix)
+    cov_map.initialize_pixels(unique_cov_pix)
+    sparse_indices = pixels + cov_map[cov_pix]
+    sparse_map = np.full(
+        (len(unique_cov_pix) + 1) * cov_map.nfine_per_cov, sentinel, dtype=np.float32
+    )
+    sparse_map[sparse_indices] = values.astype(np.float32)
+    return hsp.HealSparseMap(
+        cov_map=cov_map,
+        sparse_map=sparse_map,
+        nside_sparse=nside,
+        sentinel=sentinel,
+    )
+
+
 def take_from_sorted(
     healpix_map: "HealpixMap", sort_by: str, invert: bool, n: int, at: str | int
 ):
@@ -352,29 +376,11 @@ class HealpixMap(dict):
 
         elif format == "healsparse":
             pixels = table["pixel"].value
-            sentinel = np.float32(hp.UNSEEN)
-
-            # Build coverage map once and compute sparse indices once,
-            # shared across all columns to avoid repeating this work.
-            cov_map = hsp.HealSparseCoverage.make_empty(self.nside_lr, self.nside)
-            cov_pix = cov_map.cov_pixels(pixels)
-            unique_cov_pix = np.unique(cov_pix)
-            cov_map.initialize_pixels(unique_cov_pix)
-            sparse_indices = pixels + cov_map[cov_pix]
-            sparse_map_size = (len(unique_cov_pix) + 1) * cov_map.nfine_per_cov
-
-            dict_maps = {}
-            for name, col in table.items():
-                if name != "pixel":
-                    sparse_map = np.full(sparse_map_size, sentinel, dtype=np.float32)
-                    sparse_map[sparse_indices] = col.value.astype(np.float32)
-                    dict_maps[name] = hsp.HealSparseMap(
-                        cov_map=cov_map,
-                        sparse_map=sparse_map,
-                        nside_sparse=self.nside,
-                        sentinel=sentinel,
-                    )
-            return dict_maps
+            return {
+                name: make_healsparse_map(pixels, col.value, self.nside, self.nside_lr)
+                for name, col in table.items()
+                if name != "pixel"
+            }
 
     @property
     def data(self):

--- a/python/opencosmo/collection/lightcone/healpix_map.py
+++ b/python/opencosmo/collection/lightcone/healpix_map.py
@@ -374,11 +374,28 @@ class HealpixMap(dict):
             table = next(table.itercols())
 
         if format == "healpix":
+            npix = hp.nside2npix(self.nside)
             if isinstance(table, (u.Quantity, Column)):
-                return table.value
+                vals = np.zeros(npix, dtype=np.float32)
+                vals[pixels] = table.value
+                storage = {"vals": vals}
+
             else:
                 table.remove_columns(self.__hidden)
-                return {name: col.value for name, col in table.items()}
+                storage = {
+                    name: np.zeros(npix, dtype=np.float32) for name in table.columns
+                }
+                for name, arr in storage.items():
+                    arr[pixels] = table[name].value
+            if len(pixels) != hp.nside2npix(self.nside):
+                mask = np.zeros(hp.nside2npix(self.nside), dtype=bool)
+                mask[pixels] = True
+                storage = {
+                    name: np.ma.masked_array(arr, mask) for name, arr in storage.items()
+                }
+            if len(storage) == 1:
+                return next(iter(storage.values()))
+            return storage
 
         elif format == "healsparse":
             return make_healsparse_maps(table, self.nside, self.nside_lr)

--- a/python/opencosmo/collection/lightcone/healpix_map.py
+++ b/python/opencosmo/collection/lightcone/healpix_map.py
@@ -332,7 +332,8 @@ class HealpixMap(dict):
 
         You can get the data in two formats, "healsparse" (the default) and "healpix".
         "healsparse" format will return the data as a healsparse sparse map.
-        "healpix" will return the data as a dictionary of numpy arrays. For map data,
+        "healpix" will return the data as a dictionary of numpy arrays. If the map does not
+        cover the full sky, this wll be a masked numpy array. For map data,
         due to format requirements, no units will be attached to the data itself,
         although these will match the units from the data attributes.
 

--- a/python/opencosmo/collection/lightcone/healpix_map.py
+++ b/python/opencosmo/collection/lightcone/healpix_map.py
@@ -33,28 +33,34 @@ if TYPE_CHECKING:
     from opencosmo.spatial import Region
 
 
-def make_healsparse_map(
-    pixels: np.ndarray,
-    values: np.ndarray,
+def make_healsparse_maps(
+    table,
     nside: int,
     nside_lr: int,
-) -> hsp.HealSparseMap:
+) -> dict[str, hsp.HealSparseMap]:
     sentinel = np.float32(hp.UNSEEN)
+    pixels = table["pixel"].value
+
+    # Build coverage map once, shared across all columns.
     cov_map = hsp.HealSparseCoverage.make_empty(nside_lr, nside)
     cov_pix = cov_map.cov_pixels(pixels)
     unique_cov_pix = np.unique(cov_pix)
     cov_map.initialize_pixels(unique_cov_pix)
     sparse_indices = pixels + cov_map[cov_pix]
-    sparse_map = np.full(
-        (len(unique_cov_pix) + 1) * cov_map.nfine_per_cov, sentinel, dtype=np.float32
-    )
-    sparse_map[sparse_indices] = values.astype(np.float32)
-    return hsp.HealSparseMap(
-        cov_map=cov_map,
-        sparse_map=sparse_map,
-        nside_sparse=nside,
-        sentinel=sentinel,
-    )
+    sparse_map_size = (len(unique_cov_pix) + 1) * cov_map.nfine_per_cov
+
+    result = {}
+    for name, col in table.items():
+        if name != "pixel":
+            sparse_map = np.full(sparse_map_size, sentinel, dtype=np.float32)
+            sparse_map[sparse_indices] = col.value.astype(np.float32)
+            result[name] = hsp.HealSparseMap(
+                cov_map=cov_map,
+                sparse_map=sparse_map,
+                nside_sparse=nside,
+                sentinel=sentinel,
+            )
+    return result
 
 
 def take_from_sorted(
@@ -375,12 +381,7 @@ class HealpixMap(dict):
                 return {name: col.value for name, col in table.items()}
 
         elif format == "healsparse":
-            pixels = table["pixel"].value
-            return {
-                name: make_healsparse_map(pixels, col.value, self.nside, self.nside_lr)
-                for name, col in table.items()
-                if name != "pixel"
-            }
+            return make_healsparse_maps(table, self.nside, self.nside_lr)
 
     @property
     def data(self):

--- a/python/opencosmo/collection/lightcone/healpix_map.py
+++ b/python/opencosmo/collection/lightcone/healpix_map.py
@@ -340,12 +340,6 @@ class HealpixMap(dict):
         table["pixel"] = pixels
         table.sort("pixel", reverse=False)
 
-        if format == "healpix":
-            if self.__len__() != hp.nside2npix(self.nside):
-                raise ValueError(
-                    "healpix format chosen but length of dataset doesn't match nside value. Use healsparse"
-                )
-
         if len(table.colnames) == 1:
             table = next(table.itercols())
 
@@ -355,15 +349,31 @@ class HealpixMap(dict):
             else:
                 table.remove_columns(self.__hidden)
                 return {name: col.value for name, col in table.items()}
+
         elif format == "healsparse":
+            pixels = table["pixel"].value
+            sentinel = np.float32(hp.UNSEEN)
+
+            # Build coverage map once and compute sparse indices once,
+            # shared across all columns to avoid repeating this work.
+            cov_map = hsp.HealSparseCoverage.make_empty(self.nside_lr, self.nside)
+            cov_pix = cov_map.cov_pixels(pixels)
+            unique_cov_pix = np.unique(cov_pix)
+            cov_map.initialize_pixels(unique_cov_pix)
+            sparse_indices = pixels + cov_map[cov_pix]
+            sparse_map_size = (len(unique_cov_pix) + 1) * cov_map.nfine_per_cov
+
             dict_maps = {}
             for name, col in table.items():
                 if name != "pixel":
-                    hsp_out = hsp.HealSparseMap.make_empty(
-                        self.nside_lr, self.nside, dtype=np.float32
+                    sparse_map = np.full(sparse_map_size, sentinel, dtype=np.float32)
+                    sparse_map[sparse_indices] = col.value.astype(np.float32)
+                    dict_maps[name] = hsp.HealSparseMap(
+                        cov_map=cov_map,
+                        sparse_map=sparse_map,
+                        nside_sparse=self.nside,
+                        sentinel=sentinel,
                     )
-                    hsp_out[table["pixel"].value] = (col.value).astype(np.float32)
-                    dict_maps[name] = hsp_out
             return dict_maps
 
     @property

--- a/test/parallel/test_lc_mpi.py
+++ b/test/parallel/test_lc_mpi.py
@@ -133,7 +133,7 @@ def test_healpix_write(haloproperties_600_path, per_test_dir):
     oc.write(per_test_dir / "lightcone_test.hdf5", ds)
     new_ds = oc.open(per_test_dir / "lightcone_test.hdf5")
 
-    radius2 = 2 * u.deg
+    radius2 = 1 * u.deg
     region2 = oc.make_cone(center, radius2)
     new_ds = new_ds.bound(region2)
     ds = ds.bound(region2)

--- a/test/test_healpixmap.py
+++ b/test/test_healpixmap.py
@@ -2,10 +2,9 @@ import astropy.units as u
 import healpy as hp
 import healsparse as hsp
 import numpy as np
+import opencosmo as oc
 import pytest
 from astropy.coordinates import SkyCoord
-
-import opencosmo as oc
 from opencosmo.spatial.healpix import HealpixRegion
 
 
@@ -299,6 +298,14 @@ def test_healpix_collection_select(healpix_map_path):
     ds = ds.select(to_select)
     columns_found = set(ds.columns)
     assert columns_found == to_select
+
+
+def test_healpix_collection_take_healpix(healpix_map_path):
+    ds = oc.open(healpix_map_path)
+    ds = ds.take_range(500, 1000)
+    data = ds.get_data("healpix")
+    for value in data.values():
+        assert np.all(np.where(value.mask)[0] == np.arange(500, 1000))
 
 
 def test_healpix_collection_select_healsparse(healpix_map_path):


### PR DESCRIPTION
This PR updates the HealpixMap to initialize HealSparseMaps manually, rather than relying on make_empty + direct assignment. This speeds up the HealsparseMap test suite by approxiamately a factor of 5.
