### PR TITLE
more flexibility for defining pyxSIM source models

### DIFF
--- a/changes/+c9227926.improvement.rst
+++ b/changes/+c9227926.improvement.rst
@@ -1,0 +1,1 @@
+Extending the pyxsim integration to use source models other than just CIESourceModel

--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -58,7 +58,7 @@ When ``compute_xray_fields=True``, the function internally creates a :class:`pyx
 - X-ray luminosity in a user-specified energy band
 - Any additional fields required for photon sampling (e.g., emission measure)
 
-Note that it is possible to use other source model types through this interface (e.g. `PowerLawSourceModel` or `LineSourceModel`); however, additional particle data columns will need to be derived to use this functionality. Model-specific configurations can be specified via the ``source_model_kwargs`` argument, which is forwarded directly to the source model's constructor. Common options include:
+Note that it is possible to use other source model types through this interface (e.g. ``PowerLawSourceModel`` or ``LineSourceModel``); however, additional particle data columns will need to be derived to use this functionality. Model-specific configurations can be specified via the ``source_model_kwargs`` argument, which is forwarded directly to the source model's constructor. Common options include:
 
 - ``emin`` (float): Minimum photon energy in keV (default: 0.1)
 - ``emax`` (float): Maximum photon energy in keV (default: 10.0)
@@ -66,9 +66,9 @@ Note that it is possible to use other source model types through this interface 
 - ``model`` (str): which emission model to use (default: "apec")
 
 For the full list of options and requirements, refer to pyxSIM's `documentation <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/source_models/index.html>`_.
-If ``return_source_model=True``, the function will return a 2-tuple ``(ds, source_model)``, where ``source_model`` is the ``SourceModel`` instance. This allows further customization or photon generation using pyXSIM directly. Note that the ``compute_xray_fields`` functionality is provided for convenience, and that pyxSIM's functionality can be equivalently accessed by manually defining the source model and any required fields directly on the yt dataset. There are many examples of how to do this in the pyxSIM `cookbook <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/cookbook/index.html>`_. 
+If ``return_source_model=True``, the function will return a 2-tuple ``(ds, source_model)``, where ``source_model`` is the ``SourceModel`` instance. This allows further customization or photon generation using pyXSIM directly. Note that the ``compute_xray_fields`` option is provided for convenience, and that pyxSIM's functionality can be equivalently accessed by manually defining the source model and any required fields directly on the yt dataset. There are many examples of how to do this in the pyxSIM `cookbook <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/cookbook/index.html>`_. 
 
-We will now edit the code-block from before to compute X-ray luminosities using the `CIESourceModel`:
+We will now edit the code-block from before to compute X-ray luminosities using the ``CIESourceModel``:
 
 .. code-block:: python
 
@@ -104,7 +104,7 @@ The two primary functions for this purpose are:
 - :func:`opencosmo.analysis.visualize_halo` — a simple 2x2 panel plot for one halo
 - :func:`opencosmo.analysis.halo_projection_array` — a customizable grid of halos and fields
 
-These use yt under the hood, and are useful for visually inspecting halos with minimal input required. Animated versions of the visualizations outputted by either of these functions can be made using :func:`opencosmo.analysis.animate_halos`.
+These use yt under the hood, and are useful for visually inspecting halos with minimal input required. Animated versions of the visualizations outputted by either of these functions can be made using :func:`opencosmo.analysis.animate_halos`. Note that animated versions of any of these figures can be made with :func:`opencosmo.analysis.animate_halos`.
 
 
 Quick Projections

--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -52,24 +52,23 @@ Simulating X-ray Emission with pyXSIM
 
 To include synthetic X-ray emissivity and luminosity fields from gas particles in your yt dataset, you can enable the ``compute_xray_fields`` flag when calling :func:`opencosmo.analysis.create_yt_dataset`. This integrates with `pyXSIM <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/>`_, a toolkit for generating synthetic X-ray observations from simulation data.
 
-When ``compute_xray_fields=True``, the function internally creates a :class:`pyxsim.CIESourceModel` using the particle data and attaches the following derived fields to the `yt` dataset:
+When ``compute_xray_fields=True``, the function internally creates a :class:`pyxsim.SourceModel` using the particle data. By default, this creates a :class:`pyxsim.CIESourceModel` object and attaches the following derived fields to the `yt` dataset:
 
 - X-ray emissivity per particle
 - X-ray luminosity in a user-specified energy band
 - Any additional fields required for photon sampling (e.g., emission measure)
 
-You can also pass model-specific configurations via the ``source_model_kwargs`` argument, which is forwarded directly to the :class:`pyxsim.CIESourceModel` constructor. Common options include:
+Note that it is possible to use other source model types through this interface (e.g. `PowerLawSourceModel` or `LineSourceModel`); however, additional particle data columns will need to be derived to use this functionality. Model-specific configurations can be specified via the ``source_model_kwargs`` argument, which is forwarded directly to the source model's constructor. Common options include:
 
 - ``emin`` (float): Minimum photon energy in keV (default: 0.1)
 - ``emax`` (float): Maximum photon energy in keV (default: 10.0)
 - ``nbins`` (int): Number of bins across the energy band (default: 1000)
 - ``model`` (str): which emission model to use (default: "apec")
 
-For the full list of options, see `CIESourceModel <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/api/source_models.html#pyxsim.source_models.thermal_sources.CIESourceModel>`_.
+For the full list of options and requirements, refer to pyxSIM's `documentation <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/source_models/index.html>`_.
+If ``return_source_model=True``, the function will return a 2-tuple ``(ds, source_model)``, where ``source_model`` is the ``SourceModel`` instance. This allows further customization or photon generation using pyXSIM directly. Note that the ``compute_xray_fields`` functionality is provided for convenience, and that pyxSIM's functionality can be equivalently accessed by manually defining the source model and any required fields directly on the yt dataset. There are many examples of how to do this in the pyxSIM `cookbook <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/cookbook/index.html>`_. 
 
-If ``return_source_model=True``, the function will return a 2-tuple ``(ds, source_model)``, where ``source_model`` is the ``CIESourceModel`` instance. This allows further customization or photon generation using pyXSIM directly.
-
-We will now edit the code-block from before to compute X-ray luminosities:
+We will now edit the code-block from before to compute X-ray luminosities using the `CIESourceModel`:
 
 .. code-block:: python
 

--- a/python/opencosmo/analysis/yt_utils.py
+++ b/python/opencosmo/analysis/yt_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Tuple, Union
 
 import numpy as np
 import yt  # type: ignore

--- a/python/opencosmo/analysis/yt_utils.py
+++ b/python/opencosmo/analysis/yt_utils.py
@@ -10,7 +10,7 @@ from unyt import unyt_array, unyt_quantity  # type: ignore
 
 if TYPE_CHECKING:
     from yt.data_objects.static_output import Dataset as YT_Dataset
-    from pyxsim.source_models.sources import SourceModel
+    from pyxsim.source_models.sources import SourceModel # type: ignore
     import opencosmo as oc
 
 # ---- define some constants ---- #
@@ -22,11 +22,11 @@ solar_metallicity = 0.012899  # value used internally in HACC
 
 def create_yt_dataset(
     data: Dict[str, oc.Dataset],
-    compute_xray_fields: Optional[bool] = False,
-    return_source_model: Optional[bool] = False,
-    pyxsim_source_model: Optional[str] = "CIESourceModel",
-    source_model_kwargs: Optional[Dict[str, Any]] = {},
-    make_line_source_fields_kwargs: Optional[Dict[str, Any]] = {},
+    compute_xray_fields: bool = False,
+    return_source_model: bool = False,
+    pyxsim_source_model: str = "CIESourceModel",
+    source_model_kwargs: Dict[str, Any] = {},
+    make_line_source_fields_kwargs: Dict[str, Any] = {},
 ) -> Union[YT_Dataset, Tuple[YT_Dataset, SourceModel]]:
     """
     Converts particle data to a `yt` dataset. Note that `yt`
@@ -66,7 +66,7 @@ def create_yt_dataset(
         vary between source model types (`docs <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/source_models/index.html#>`_).
     make_line_source_fields_kwargs : dict, optional
         Dictionary for setting keyword arguments of pyxsim's `make_line_source_fields()` function (`ref <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/api/source_models.html#pyxsim.source_models.sources.SourceModel.make_line_source_fields#>`_). 
-        This is only relevent if `pyxsim_source_model=="LineSourceModel"`. The `ds` yt dataset parameter will be set internally by `create_yt_dataset()`, 
+        This is only relevent if ``pyxsim_source_model=="LineSourceModel"``. The `ds` yt dataset parameter will be set internally by `create_yt_dataset()`, 
         so `ds` should not be set to be set in this `make_line_source_fields_kwargs`.
 
     Returns
@@ -76,7 +76,7 @@ def create_yt_dataset(
         (e.g., X-ray luminosities) if requested.
 
     source_model : pyxsim.source_models.CIESourceModel, optional
-        Returned only if `return_source_model=True`.
+        Returned only if ``return_source_model==True``.
     """
 
     data_dict: Dict[

--- a/python/opencosmo/analysis/yt_utils.py
+++ b/python/opencosmo/analysis/yt_utils.py
@@ -6,12 +6,11 @@ import numpy as np
 import yt  # type: ignore
 import pyxsim # type: ignore
 from astropy.table import Table
-from pyxsim.source_models.sources import SourceModel  # type: ignore
 from unyt import unyt_array, unyt_quantity  # type: ignore
 
 if TYPE_CHECKING:
     from yt.data_objects.static_output import Dataset as YT_Dataset
-
+    from pyxsim.source_models.sources import SourceModel
     import opencosmo as oc
 
 # ---- define some constants ---- #
@@ -27,6 +26,7 @@ def create_yt_dataset(
     return_source_model: Optional[bool] = False,
     pyxsim_source_model: Optional[str] = "CIESourceModel",
     source_model_kwargs: Optional[Dict[str, Any]] = {},
+    make_line_source_fields_kwargs: Optional[Dict[str, Any]] = {},
 ) -> Union[YT_Dataset, Tuple[YT_Dataset, SourceModel]]:
     """
     Converts particle data to a `yt` dataset. Note that `yt`
@@ -64,6 +64,10 @@ def create_yt_dataset(
         These can include parameters like `emin`, `emax`, `nbins`, `abund_table`, etc.,
         to control the spectral resolution and emission model behavior. Available parameters
         vary between source model types (`docs <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/source_models/index.html#>`_).
+    make_line_source_fields_kwargs : dict, optional
+        Dictionary for setting keyword arguments of pyxsim's `make_line_source_fields()` function (`ref <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/api/source_models.html#pyxsim.source_models.sources.SourceModel.make_line_source_fields#>`_). 
+        This is only relevent if `pyxsim_source_model=="LineSourceModel"`. The `ds` yt dataset parameter will be set internally by `create_yt_dataset()`, 
+        so `ds` should not be set to be set in this `make_line_source_fields_kwargs`.
 
     Returns
     -------
@@ -244,7 +248,7 @@ def create_yt_dataset(
             # populate yt dataset with xray fields
             if pyxsim_source_model == "LineSourceModel":
                 source.make_line_source_fields(
-                    ds, source_model_kwargs["e0"], line_width, line_name
+                    ds, **make_line_source_fields_kwargs,  
                 )
             else:
                 source.make_source_fields(

--- a/python/opencosmo/analysis/yt_utils.py
+++ b/python/opencosmo/analysis/yt_utils.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import yt  # type: ignore
+import pyxsim # type: ignore
 from astropy.table import Table
-from pyxsim import CIESourceModel  # type: ignore
+from pyxsim.source_models.sources import SourceModel  # type: ignore
 from unyt import unyt_array, unyt_quantity  # type: ignore
 
 if TYPE_CHECKING:
@@ -24,8 +25,9 @@ def create_yt_dataset(
     data: Dict[str, oc.Dataset],
     compute_xray_fields: Optional[bool] = False,
     return_source_model: Optional[bool] = False,
+    pyxsim_source_model: Optional[str] = "CIESourceModel",
     source_model_kwargs: Optional[Dict[str, Any]] = {},
-) -> Union[YT_Dataset, Tuple[YT_Dataset, CIESourceModel]]:
+) -> Union[YT_Dataset, Tuple[YT_Dataset, SourceModel]]:
     """
     Converts particle data to a `yt` dataset. Note that `yt`
     is generally developed with AMR codes in mind, but support for
@@ -42,17 +44,26 @@ def create_yt_dataset(
         A dictionary of particle datasets. Must include at least positions and masses.
     compute_xray_fields : bool, optional
         Whether or not to compute X-ray luminosities with `pyxsim`.
-        Uses `CIESourceModel`, which considers thermal emission from gas assuming
+        Uses `CIESourceModel` by default, which considers thermal emission from gas assuming
         collisional ionization equilibrium.
     return_source_model : bool, optional
         Whether or not to return the `pyxsim` source model for further interaction,
         such as computing additional luminosities in different frequency bands
         or generating synthetic observations.
+    pyxsim_source_model : str, optional
+        Which `SourceModel` to use for generating X-ray emission. See `pyxsim's` 
+        `documentation <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/source_models/index.html#>`_ for options.
+        Some source models have required inputs, which can be set here using the `source_model_kwargs` parameter. 
+        If `CIESourceModel` is chosen, an emission measure field will be computed, and default values will be used for all source model parameters.
+        For other source models (e.g. `PowerLawSourceModel` or `LineSourceModel`), additional particle data columns
+        will need to be defined before calling this function. Alternatively, one could call `create_yt_dataset()` with
+        `compute_xray_fields=False` and manually define the additional fields and pyxsim source models using the 
+        obtained yt dataset. See pyxsim's `cookbook <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/cookbook/index.html#>`_ for examples.
     source_model_kwargs : dict, optional
-        Keyword arguments passed to the `CIESourceModel` constructor in `pyxsim`.
+        Keyword arguments passed to the source model constructor in `pyxsim`.
         These can include parameters like `emin`, `emax`, `nbins`, `abund_table`, etc.,
-        to control the spectral resolution and emission model behavior. If `None`,
-        default values will be used for all source model parameters.
+        to control the spectral resolution and emission model behavior. Available parameters
+        vary between source model types (`docs <https://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/source_models/index.html#>`_).
 
     Returns
     -------
@@ -203,38 +214,42 @@ def create_yt_dataset(
             # This calls CIESourceModel, which assumes ionization equilibrium.
             # User can define custom parameters
 
-            ds.add_field(
-                ("gas", "emission_measure"),
-                function=_emission_measure,
-                units="cm**-3",
-                sampling_type="particle",
-            )
-
-            default_kwargs = {
-                "model": "apec",
-                "emin": 0.1,  # keV
-                "emax": 10.0,  # keV
-                "nbins": 1000,
-                "Zmet": ("gas", "metallicity"),  # Zsun
-                "temperature_field": ("gas", "temperature"),
-                "emission_measure_field": ("gas", "emission_measure"),
-                "h_fraction": "xh",
-            }
-
-            if source_model_kwargs is None:
-                source_model_kwargs = {}
+            if pyxsim_source_model == "CIESourceModel":
+                ds.add_field(
+                    ("gas", "emission_measure"),
+                    function=_emission_measure,
+                    units="cm**-3",
+                    sampling_type="particle",
+                )
+                default_kwargs = {
+                    "model": "apec",
+                    "emin": 0.1,  # keV
+                    "emax": 10.0,  # keV
+                    "nbins": 1000,
+                    "Zmet": ("gas", "metallicity"),  # Zsun
+                    "temperature_field": ("gas", "temperature"),
+                    "emission_measure_field": ("gas", "emission_measure"),
+                    "h_fraction": "xh",
+                }
+            else:
+                default_kwargs = {}
 
             # update with user-defined settings
             source_model_kwargs = {**default_kwargs, **source_model_kwargs}
 
             # define xray source model (
             # NOTE: this will download a few fits files needed for the analysis)
-            source = CIESourceModel(**source_model_kwargs)
+            source = getattr(pyxsim, pyxsim_source_model)(**source_model_kwargs)
 
             # populate yt dataset with xray fields
-            source.make_source_fields(
-                ds, source_model_kwargs["emin"], source_model_kwargs["emax"]
-            )
+            if pyxsim_source_model == "LineSourceModel":
+                source.make_line_source_fields(
+                    ds, source_model_kwargs["e0"], line_width, line_name
+                )
+            else:
+                source.make_source_fields(
+                    ds, source_model_kwargs["emin"], source_model_kwargs["emax"]
+                )
 
             if return_source_model:
                 return ds, source


### PR DESCRIPTION
Before, the only option was to create a CIESourceModel. This is still the default behavior, but users can create other source models now too (e.g. PowerLawSourceModel or LineSourceModel).