### PR TITLE
Fix Lightcone Structure Sparse Writes

### DIFF
--- a/changes/+15d144c7.bugfix.rst
+++ b/changes/+15d144c7.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that could cause writes of sparse lightcone structure collections to fail in MPI environments.

--- a/python/opencosmo/collection/lightcone/lightcone.py
+++ b/python/opencosmo/collection/lightcone/lightcone.py
@@ -1158,9 +1158,11 @@ class Lightcone(dict):
         for (name, ds), index in zip(self.items(), projected):
             output[name] = ds.take_rows(index)
         if all(len(ds) == 0 for ds in output.values()):
-            output = {"data": next(iter(output.values()))}
+            key = next(iter(output.keys()))
+            output = {key: output[key]}
+
         else:
-            output = {name: ds for name, ds in output.items() if len(ds) != 0}
+            output = {key: ds for key, ds in output.items() if len(ds) > 0}
 
         return Lightcone(output, self.z_range, self.__hidden, self.__sort_key)
 

--- a/python/opencosmo/collection/lightcone/stack.py
+++ b/python/opencosmo/collection/lightcone/stack.py
@@ -154,11 +154,12 @@ def stack_lightcone_datasets_in_schema(
     n_datasets = sum(len(lst) for lst in datasets.values())
     if n_datasets == 1 and get_comm_world() is None:
         dataset_list = next(iter(datasets.values()))
+        dataset_name = next(iter(datasets.keys()))
 
         schema = dataset_list[0].make_schema(name=name)
         header = sync_headers(dataset_list, redshift_range)
         schema.children["header"] = header
-        return {"data": schema}
+        return {dataset_name: schema}
 
     schema_children = {}
     ds_groups = get_all_keys(datasets, get_comm_world())

--- a/python/opencosmo/io/mpi.py
+++ b/python/opencosmo/io/mpi.py
@@ -7,7 +7,7 @@ import h5py
 import numpy as np
 
 from opencosmo.io.schema import FileEntry, Schema, make_schema
-from opencosmo.io.verify import ZeroLengthError, verify_file
+from opencosmo.io.verify import schema_data_length, verify_structure
 from opencosmo.io.writer import ColumnCombineStrategy, ColumnWriter
 from opencosmo.mpi import MPI, get_comm_world
 
@@ -68,13 +68,17 @@ def write_parallel(file: Path, file_schema: Schema):
         raise ValueError("Different ranks recieved a different path to output to!")
 
     try:
-        verify_file(file_schema)  # Initial verification
-        results = comm.allgather(CombineState.VALID)
+        verify_structure(file_schema)  # Tier 1: structural correctness
+        # Tier 2: does this rank actually contribute any rows?
+        state = (
+            CombineState.VALID
+            if schema_data_length(file_schema) > 0
+            else CombineState.ZERO_LENGTH
+        )
+        results = comm.allgather(state)
     except ValueError:
         results = comm.allgather(CombineState.INVALID)
         raise
-    except ZeroLengthError:
-        results = comm.allgather(CombineState.ZERO_LENGTH)
     if any(rs == CombineState.INVALID for rs in results):
         raise ValueError("One or more ranks recieved invalid schemas!")
 

--- a/python/opencosmo/io/verify.py
+++ b/python/opencosmo/io/verify.py
@@ -8,17 +8,26 @@ if TYPE_CHECKING:
     from .schema import Schema
 
 
-""" 
-Verification is just a check to make sure that the data going into the file is valid. It is intentionally centralized,
-such that if you create a new data type and implement "make_schema" it will fail at this step until you add verification.
+"""
+Verification is split into two independent tiers, each with its own return channel:
+
+1. ``verify_structure`` checks that a schema is *well-formed*. It raises
+   ``ValueError`` on genuine corruption and never inspects row counts, so a
+   zero-length dataset (or an empty lightcone partition) is structurally valid.
+2. ``schema_data_length`` reports how many data rows *this rank* actually
+   contributes. It is a pure, local computation that never raises.
+
+Keeping the two concerns separate is what lets an MPI write distinguish a rank
+that holds no data (excluded from the write) from a rank whose schema is broken
+(a hard error), without one empty sub-group poisoning the whole rank.
+
+Verification is intentionally centralized, such that if you create a new data
+type and implement "make_schema" it will fail at this step until you add
+verification.
 """
 
 
-class ZeroLengthError(Exception):
-    pass
-
-
-def verify_file(
+def verify_structure(
     schema: Schema,
 ):
     match schema.type:
@@ -41,12 +50,44 @@ def verify_file(
             raise ValueError("Unknown file structure!")
 
 
-def verify_column_group(schema: Schema, require_data: bool = False):
+def data_group_length(schema: Schema) -> int:
+    """
+    Number of rows in a node's direct "data" group, or 0 if it has none.
+    """
+    if "data" not in schema.children:
+        return 0
+    column = next(iter(schema.children["data"].columns.values()), None)
+    return 0 if column is None else column.shape[0]
+
+
+def schema_data_length(schema: Schema) -> int:
+    """
+    Total number of data rows this rank will contribute for a schema. Purely
+    local: MPI callers combine the per-rank totals themselves. Container nodes
+    sum their children; the default arm returns 0 so recursion never descends
+    into index/header/data_linked groups.
+    """
+    match schema.type:
+        case FileEntry.DATASET | FileEntry.HEALPIX_MAP:
+            return data_group_length(schema)
+        case FileEntry.LIGHTCONE:
+            if "data" in schema.children:  # single-dataset lightcone
+                return data_group_length(schema)
+            return sum(schema_data_length(c) for c in schema.children.values())
+        case FileEntry.STRUCTURE_COLLECTION | FileEntry.SIMULATION_COLLECTION:
+            return sum(schema_data_length(c) for c in schema.children.values())
+        case _:
+            return 0
+
+
+def verify_column_group(schema: Schema):
     """
     Verify that a given data group is valid. This requires that:
     1. All column writers have the same length
     2. All columns have the same combine strategy
     3. All columns are in the same group
+
+    Note this is a structural check only: a zero-length group is valid.
     """
     column_names = set()
     group_names = set()
@@ -69,8 +110,7 @@ def verify_column_group(schema: Schema, require_data: bool = False):
         raise ValueError(
             "Columns within a single group should always have the same length!"
         )
-    elif (group_length := all_column_lengths.pop()) == 0 and require_data:
-        raise ZeroLengthError
+    group_length = all_column_lengths.pop()
 
     if len(column_strategies) != 1:
         raise ValueError(
@@ -101,9 +141,7 @@ def verify_dataset_data(schema: Schema, has_index=True):
         if name not in ["data", "index"] and child.type == FileEntry.COLUMNS
     ]
 
-    _, data_length, data_combine_strategy = verify_column_group(
-        schema.children["data"], require_data=True
-    )
+    _, data_length, data_combine_strategy = verify_column_group(schema.children["data"])
     if has_index:
         for child in schema.children["index"].children.values():
             verify_column_group(child)
@@ -121,10 +159,13 @@ def verify_lightcone_collection_schema(schema: Schema):
     can also technically be a lighcone collection, if is_lightcone is
     set to true in its header. Mostly just delegates to underlying
     dataset checks.
+
+    A lightcone with no children is structurally valid: it is how an empty
+    partition (a rank that received none of the sampled structures) is
+    represented. Whether it actually has data is decided by
+    ``schema_data_length``, not here.
     """
-    if len(schema.children) < 1:
-        raise ValueError("Expect at least one lightcone child!")
-    elif "data" in schema.children:
+    if "data" in schema.children:
         # Single-dataset lightcone
         return verify_dataset_data(schema)
     for key, child_schema in schema.children.items():


### PR DESCRIPTION
Introduces a changes that fixes sparse lightcone structure collection writes in MPI contexts.

- Schema verification now splits structure and length verification steps
- Lightcone is now more intelligent about how it handles keys when taking zero rows
