### PR TITLE
Smarter column selections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,197 @@
+# AGENTS.md
+
+This file provides guidance to coding agents working in this repository.
+
+## Project Overview
+
+OpenCosmo is a Python toolkit for reading, writing, and lazily transforming data from cosmological simulations produced by Argonne National Laboratory's CPAC group. It reads HDF5 files with full unit awareness and can materialize standard datasets as Astropy, NumPy, pandas, Polars, Arrow, or JAX containers. HEALPix maps use HealSparse or HEALPix array outputs.
+
+## Repo Layout
+
+The repository is a hybrid Rust/Python project built with **maturin**:
+
+```text
+src/                         — PyO3/Rust extension source
+python/opencosmo/            — Python package
+  dataset/                   — Dataset facade, immutable state, and materialization
+  collection/                — Lightcone, map, structure, and simulation collections
+  column/                    — Expressions, reducers, evaluation, and cache
+  handler/                   — Raw data/cache protocols and HDF5 handlers
+  index/                     — Index arithmetic and index-aware HDF5 reads
+  io/                        — Discovery, file specs, MPI planning, and writers
+  spatial/                   — Regions, trees, octree, and HEALPix indexing
+  units/                     — Unit conventions and lazy conversion
+  dtypes/                    — Pydantic header models and registries
+  plugins/                   — Internal hook registry and contexts
+  analysis/                  — CLI and analysis integrations
+  serde/                     — Serialization and UI-facing models
+test/                        — Serial and MPI tests
+docs/source/                 — Sphinx documentation
+changes/                     — Towncrier fragments
+plans/                       — Design and implementation notes
+```
+
+The Rust extension compiles to `opencosmo._lib` and is imported by the Python `index/` module.
+
+## Commands
+
+### Setup
+```bash
+uv sync                          # Install all dev dependencies (compiles Rust extension)
+uv sync --group mpi --group test-mpi  # Add MPI support
+```
+
+### Testing
+Tests require the repository-local `test_data/` directory, which is distributed separately. Run:
+```bash
+uv run pytest --ignore=test/parallel          # All non-parallel tests
+uv run pytest test/test_dataset.py            # Single test file
+uv run pytest test/test_dataset.py::test_name # Single test
+uv run mpiexec -n 4 pytest -m parallel test/parallel -x  # MPI tests
+```
+
+Test data fixtures are in `test/conftest.py`. The fixtures (`snapshot_path`, `lightcone_path`, `map_path`, `diffsky_path`, `analysis_path`) resolve to subdirectories under `test_data/`.
+
+### Linting & Type Checking
+```bash
+uv run ruff check python/        # Lint
+uv run ruff format python/       # Format
+uv run mypy python/              # Type checking
+```
+
+### Changelog
+```bash
+uv run towncrier create <issue_number>.<type>  # Types: feature, bugfix, improvement, doc, removal, misc
+```
+
+## Coding Guidelines
+
+- Prefer functional code. Make classes immutable whenever possible; user-facing classes must always be immutable. Prefer frozen dataclasses for backend containers.
+- Avoid helper methods unless they are necessary. Prefix helper methods with `__` so they are name-mangled.
+- Prefix backend module functions with `__` when they are not used outside their defining module.
+- Avoid over-commenting. Add concise comments only when the logic is not obvious.
+- Do not use class inheritance except where an existing framework requires it, such as Pydantic models.
+- Add type hints to all code. Avoid `Any` whenever a more specific type can be used.
+- Target Python 3.12+ syntax. Put annotation-only imports behind `TYPE_CHECKING` unless a framework such as Pydantic requires the object at runtime.
+- Use `Protocol` for interchangeable backend or plugin contracts, `TypedDict` for established dictionary payloads, `NamedTuple` when tuple behavior matters, and frozen dataclasses for richer immutable records. Add `@runtime_checkable` only for actual runtime checks.
+- Use narrow, rule-specific `# noqa` or `# type: ignore[...]` suppressions. Do not use a broad suppression when the type or lint rule can be expressed accurately.
+- Add public names through the appropriate package `__init__.py` and `__all__`. Keep Rust bindings behind Python APIs rather than exposing `opencosmo._lib` directly.
+- Keep optional dependencies out of import-time paths. Import pandas, Polars, Arrow, JAX, yt, and MPI implementations only when requested. Serial code must handle `get_comm_world() is None`.
+- Discovery, schema construction, serialization, and MPI planning must be deterministic. Sort file, group, and column inputs and never depend on set iteration or caller path order where ranks must agree.
+- Accept `str | Path` at public file boundaries, normalize to `Path`, and use context managers for owned HDF5 resources. Frozen discovery and planning records must not retain live h5py objects.
+- Match existing exception semantics: `TypeError` for unsupported object kinds, `ValueError` for invalid domain values or combinations, filesystem-specific exceptions for paths, `UnitsError` for unit arithmetic, and `RuntimeError` for broken internal invariants. Treat changes to tested user-facing error messages as behavioral changes.
+- Public APIs use NumPy-style docstrings compatible with Sphinx Napoleon. Update the relevant guide or reference page when user-visible behavior changes.
+
+### Rust Guidelines
+
+- Keep PyO3 functions as thin `_py` wrappers that validate Python inputs and delegate to typed Rust functions using `ArrayView1<i64>` or `Array1<i64>`. Preserve Python names with `#[pyfunction(name = "...")]` and return NumPy arrays through `IntoPyArray`.
+- Preserve the repository-wide signed `int64` index invariant. Return Python exceptions for invalid input, handle empty arrays explicitly, and do not panic or use unchecked indexing for user-controlled shapes and ranges.
+
+### Test Guidelines
+
+- Prefer focused pure tests for planning and validation logic. Use shared fixtures for repository test data and `tmp_path` for generated files.
+- Test transformation immutability and user-facing errors where relevant. Use `pytest.raises(..., match=...)` when the message is part of the contract.
+- MPI tests belong under `test/parallel`, use `@pytest.mark.parallel(nprocs=4)`, and should use `parallel_assert` for rank-coordinated assertions.
+
+## Architecture
+
+### Core Data Model
+
+`Dataset` (`python/opencosmo/dataset/dataset.py`) is the primary user-facing class. Transformations (`filter`, `select`, `take`, `bound`, `with_units`, etc.) return new logical datasets. Column materialization is generally lazy and producer-driven, but filters, sorting, exact spatial bounds, and structure-link operations may read the data they need before an explicit `get_data()` call.
+
+`Dataset` wraps an immutable `DatasetState` (`dataset/state.py`) and an optional `Tree`. `DatasetState` is a frozen dataclass containing the producer graph, raw `DataHandler`, shared/derived `DataCache`, `UnitHandler`, header, visible column-to-producer UUID map, region, open kwargs, sort key, and metadata columns. Row selection lives on `raw_data_handler.index`. State transformations are standalone functions returning `dataclasses.replace(...)` copies; caches are intentionally mutable infrastructure.
+
+### Handler Layer
+
+`python/opencosmo/handler/` defines separate `DataHandler` and `DataCache` protocols. `DataHandler` provides indexed raw reads, row selection, load-condition metadata, and schema generation. `DataCache`, implemented by `ColumnCache`, stores UUID/name-keyed data and manages parent/child cache derivation and live-state registration. `Hdf5Handler` implements raw HDF5 access; `EmptyHandler` backs datasets whose values live entirely in a cache.
+
+### Index Module
+
+`python/opencosmo/index/` centralizes all index arithmetic. An index tracks which rows of a dataset are selected. Two forms exist:
+- `SimpleIndex` — a 1-D `int64` numpy array of row positions
+- `ChunkedIndex` — a `(start, size)` pair of 1-D `int64` arrays for contiguous-chunk reads
+
+`DataIndex = SimpleIndex | ChunkedIndex`. Python modules provide type dispatch, validation, HDF5 reads, and most arithmetic. Performance-critical range, expansion, take, remapping, splitting, and projection kernels are implemented in `src/index.rs` and exposed internally through `opencosmo._lib.index`.
+
+### Column Module
+
+Column materialization uses UUID-identified producers. `RawColumn` represents disk or in-memory sources, `Column` represents algebraic expressions and masks, `EvaluatedColumn` wraps user functions, and `DerivedScalarValue` represents reductions. `DatasetState.column_map` maps visible names to producer UUIDs, allowing safe column replacement. `dataset/graph.py` builds the `rustworkx` dependency DAG, and `dataset/instantiate.py` fetches and evaluates only requested transitive dependencies.
+
+`ColumnCache` persists values across related immutable states using parent/child caches and derived indices. `LocalReducer` handles in-process reductions. `MpiReducer` uses collective reductions for min/max/sum/mean and gather/broadcast for variance, standard deviation, median, and quantile.
+
+### Collections
+
+`opencosmo.open()` chooses a dataset or collection from the discovered HDF5 layout, not simply from the number of paths. A single multi-group file may produce a collection, and several redshift-step files commonly produce one `Lightcone`.
+
+- `StructureCollection` models a properties source plus datasets linked through `/data_linked` start/size or index metadata. Collections may be nested, and linked datasets are rebuilt lazily after row transformations. Iteration uses `objects()`, with `halos()` and `galaxies()` aliases.
+- `SimulationCollection` is a mapping of same-kind datasets or collections from independent simulation scopes. It maps operations across children. Redshift steps from one simulation belong in a `Lightcone`, not a `SimulationCollection`.
+- `Lightcone` presents redshift-step datasets as one dataset-like object and may be nested by step and subtype. It stacks children at materialization time and supports redshift and HEALPix-pixel pruning.
+- `LightconeScope` owns expressions that must run after children are stacked: scalar reductions and expressions depending on existing scope-owned names. Pure child expressions are routed to each child dataset.
+- `HealpixMap` wraps map data plus explicit coverage metadata. It currently supports one layer and returns HealSparse objects or nested-order HEALPix arrays through map-specific resolution and cone-query paths.
+
+Collection types are in `python/opencosmo/collection/`.
+
+### Spatial Indexing
+
+Spatial queries use `Dataset.bound(region)`. Regions are constructed via `make_box`, `make_cone`, or `make_skybox` (all public in `opencosmo`). The `spatial/` subpackage contains:
+- `models.py` — Pydantic models for region parameters (`BoxRegionModel`, `ConeRegionModel`, etc.)
+- `region.py` — concrete `Region` implementations (`FullSkyRegion`, `HealpixRegion`, etc.)
+- `relations.py` — spatial predicates (`contains_2d`, `contains_3d`, `intersects_2d`, etc.)
+- `builders.py` — `from_model()` factory; `protocols.py` — `Region` protocol
+- `octree.py` — octree for 3D snapshot data (z-order curve, level-based start/size arrays)
+- `healpix.py` — HEALPix index for 2D lightcone data (nested ordering)
+- `tree.py` — `Tree` wrapper used by `Dataset`
+
+`Tree.query()` separates fully contained chunks from boundary-intersecting chunks. `Dataset.bound()` accepts contained chunks directly and reads coordinates only for exact checks on boundary candidates. Ordinary snapshots and lightcones use octree or nested-HEALPix trees; `HealpixMap` uses explicit map coverage instead of this tree path.
+
+### HDF5 File Format
+
+OpenCosmo files are structured HDF5:
+```
+/data/           — columns (HDF5 datasets), each with optional "unit" and "description" attributes
+/header/         — simulation metadata (cosmology, parameters)
+/index/          — spatial index (level_0, level_1, ... each with start/size arrays)
+/data_linked/    — links to associated datasets (e.g., haloparticles_start, haloparticles_size)
+```
+Each logical dataset group contains `/data` and may contain sibling `/index` and `/data_linked` groups. Headers may be at the root or nested in dataset/simulation scopes; discovery assigns each `/data` group to its nearest enclosing `/header`. Multi-dataset files therefore do not necessarily share one root header. See `SPEC.md` for the full format.
+
+### Unit System
+
+Units are handled through `UnitConvention` (`python/opencosmo/units/`). Four conventions exist: `scalefree`, `comoving`, `physical`, and `unitless`. `UnitHandler` tracks the file's base convention separately from the current convention and applies registered conversions when raw data is materialized. Convention changes invalidate affected cache entries. Header Pydantic models use the separate unit registry in `dtypes/units.py`; files open in the comoving convention by default.
+
+### I/O Layer
+
+Opening follows a discover/match/plan/build pipeline:
+
+- `discover.py` walks each file once and creates frozen, picklable `FileLayout` and `GroupLayout` records without retaining HDF5 handles.
+- `specs.py` contains the ordered core `FileSpec` registry for recognizing and validating structure collections, maps, lightcones, and datasets. File-type dispatch is intentionally not a plugin extension point.
+- `plan.py` computes deterministic per-rank assignments, rehydrates live HDF5 targets, and delegates construction to the matched spec.
+- `index_spec.py` defines row-index policies for spatial partitioning, full reads, and empty reference datasets.
+- `iopen.py` orchestrates the pipeline and implements low-level `open_dataset()`.
+
+Under MPI, spatial mode gives each rank the file set and partitions source rows. Redshift mode assigns contiguous, approximately volume-balanced redshift-step groups; empty ranks open an empty-schema reference. Unsupported nested layouts fall back to spatial distribution. Discovery performs the collective metadata exchange, after which every rank computes the same deterministic assignment.
+
+Writing is schema-based. `schema.py` defines recursive `Schema` nodes, `writer.py` defines lazy column sources and combination strategies, and `serial.py`/`mpi.py` perform serial or collective HDF5 writes. `verify.py` and `updaters.py` support structural checks and metadata/index rewrites. Optional Parquet output is exposed as `opencosmo.io.write_parquet` when PyArrow is installed.
+
+### Plugin Hooks
+
+`python/opencosmo/plugins/` implements an in-process hook registry. `fold()` applies all matching transforms to frozen context dataclasses; `query()` returns the first matching non-`None` result. Hooks cover dataset/lightcone opening and instantiation, index updates, post-sort remapping, and MPI partition selection. Built-in lightcone and Diffsky hooks normalize columns and preserve host relationships. Core file recognition in `io/specs.py` remains separate from plugins.
+
+### Top-level Utility Modules
+
+Several concerns are now in dedicated top-level modules under `python/opencosmo/`:
+- `header.py` — `OpenCosmoHeader`, `read_header()`
+- `file.py` — path validation, HDF5 resource decorators, broadcast reads, and metadata utilities
+- `mpi.py` — `get_comm_world()` (returns `None` when mpi4py is absent)
+- `cosmology.py` — cosmology helpers
+- `dtypes/` — Pydantic header models and origin/data-type registries
+- `analysis/` — Click CLI plus Diffsky and yt integrations
+
+### Key Patterns
+
+- **Pydantic header models** live in `python/opencosmo/dtypes/`. Origin, data type, and lightcone status select the required and optional model groups exposed by `OpenCosmoHeader`.
+- **`from __future__ import annotations`** is used where needed. `TYPE_CHECKING` guards keep annotation-only imports out of runtime paths.
+- **Missing third-party stubs** are configured in `pyproject.toml`; source-level suppressions should remain narrow and local.
+- **`rustworkx`** is used for dependency graphs (e.g., derived column evaluation order).
+- The CLI entrypoint is `opencosmo.analysis.cli:cli` (accessible as `uv run opencosmo`).
+- Version changes must keep `pyproject.toml`, `Cargo.toml`, `opencosmo.__version__`, Sphinx `release`, and `.bumpversion.toml` synchronized.

--- a/changes/+ecd6830b.feature.rst
+++ b/changes/+ecd6830b.feature.rst
@@ -1,0 +1,1 @@
+:py:meth:`StructureCollection.select <opencosmo.StructureCollection.select>` and :py:meth:`StructureCollection.drop <opencosmo.StructureCollection.drop>` can now infer which columns belong to which datasets, allow select calls that look like dataset select calls.

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -168,6 +168,16 @@ You can still target datasets explicitly when you need to disambiguate shared co
 
 Datasets omitted from this explicit form are left unchanged. Nested collections can be selected with nested dictionaries; see :py:meth:`StructureCollection.select <opencosmo.StructureCollection.select>` for the full syntax.
 
+**Drop Follows Select Matching Rules**
+
+:py:meth:`StructureCollection.drop <opencosmo.StructureCollection.drop>` automatically matches column names, wildcards, and nested collections the same way as ``select``:
+
+.. code-block:: python
+
+   ds = ds.drop("fof_halo_mass", "*_velocity")
+
+Use dataset-keyword arguments to target datasets explicitly.
+
 **Unit Transformations Apply to All Datasets**
 
 Transforming to a different unit convention is identical to :py:meth:`opencosmo.Dataset.with_units` and always applies to all datasets in the collection:
@@ -223,4 +233,3 @@ Simulation Collections
 ----------------------
 
 SimulationCollections implement an identical API to the :py:class:`opencosmo.Dataset` or :py:class:`opencosmo.StructureCollection` it holds. All operations will automatically be mapped over all datasets held by the collection, which will always be of the same type. See the documentation for those classes for more information 
-

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -141,17 +141,32 @@ If your collection contains both a halo properties dataset and a galaxy properti
 
 However this comes with an important caveat. Filtering based on properties of a galaxy removes any halo that does not contain any a galaxy that meets the threshold. If a halo hosts multiple galaxies and at least one meets the criteria, all galaxies in the halo will be retained. 
 
-**Select Can Be Made on a Per-Dataset Basis**
+**Select Automatically Matches Columns to Datasets**
 
-You can always select subests of the columns in any of the individual datasets while keeping them housed in the collection
+:py:meth:`StructureCollection.select <opencosmo.StructureCollection.select>` matches each requested column to the datasets that contain it. This also works for derived columns and nested structure collections, so most selections do not need to name a dataset explicitly:
 
 .. code-block:: python
 
    import opencosmo as oc
    ds = oc.open("my_collection.hdf5")
-   ds = data.select(["x", "y", "z"]), dataset="dm_particles")
+   ds = ds.select(
+       "fof_halo_mass",
+       "x",
+       halo_px=oc.col("fof_halo_mass") * oc.col("fof_halo_com_vx"),
+   )
 
-If the "dataset" argument is not provided, the selection will be performed on the property dataset.
+An exact column name must exist in at least one dataset. Wildcards are applied across the collection; datasets without a match are left unchanged. If a column exists in multiple datasets, it is selected from each one.
+
+You can still target datasets explicitly when you need to disambiguate shared column names or control each dataset separately:
+
+.. code-block:: python
+
+   ds = ds.select(
+       halo_properties=["fof_halo_mass", "sod_halo_mass"],
+       dm_particles=["x", "y", "z"],
+   )
+
+Datasets omitted from this explicit form are left unchanged. Nested collections can be selected with nested dictionaries; see :py:meth:`StructureCollection.select <opencosmo.StructureCollection.select>` for the full syntax.
 
 **Unit Transformations Apply to All Datasets**
 
@@ -208,5 +223,4 @@ Simulation Collections
 ----------------------
 
 SimulationCollections implement an identical API to the :py:class:`opencosmo.Dataset` or :py:class:`opencosmo.StructureCollection` it holds. All operations will automatically be mapped over all datasets held by the collection, which will always be of the same type. See the documentation for those classes for more information 
-
 

--- a/python/opencosmo/collection/simulation/simulation.py
+++ b/python/opencosmo/collection/simulation/simulation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Mapping, Optional, Self
 
 from opencosmo.collection import structure as sc
-from opencosmo.column.select import do_multi_dataset_selections
+from opencosmo.column.select import do_multi_dataset_drops, do_multi_dataset_selections
 from opencosmo.dataset import Dataset
 from opencosmo.io.schema import FileEntry, make_schema
 
@@ -241,25 +241,34 @@ class SimulationCollection(dict):
         output = do_multi_dataset_selections(self, args, kwargs)
         return SimulationCollection(output)
 
-    def drop(self, *args, **kwargs) -> Self:
+    def drop(self, *args, **kwargs) -> SimulationCollection:
         """
-        Drop a set of columns from the datasets in the collection. This method
-        calls the underlying method in :class:`opencosmo.Dataset`, or
-        :class:`opencosmo.Collection` depending on the context. As such
-        its behavior and arguments can vary depending on what this collection
-        contains.
+        Drop columns by automatically matching their names to datasets in this
+        collection. Wildcards are applied to every dataset, while datasets
+        without a match are unchanged. For nested collections, matching follows
+        their :meth:`drop` behavior.
+
+        To target datasets explicitly, pass dataset names as keyword arguments.
+        This form is forwarded to the underlying datasets or collections.
 
         Parameters
         ----------
-        args:
-            The arguments to pass to the select method. This is
-            usually a list of column names to drop.
-        kwargs:
-            The keyword arguments to pass to the select method.
-            This is usually a dictionary of column names to select.
+        args : str or Iterable[str]
+            Column names or wildcard patterns to match automatically across all
+            datasets in the collection.
+        kwargs
+            Explicit dataset-keyed drop selections.
 
         """
-        return self.__map("drop", *args, **kwargs)
+        if self.__dtype is not Dataset:
+            return self.__map("drop", *args, **kwargs)
+
+        output = do_multi_dataset_drops(self, args)
+        for dataset_name, columns in kwargs.items():
+            if dataset_name not in self:
+                raise ValueError(f"Dataset {dataset_name} not found in collection.")
+            output[dataset_name] = output[dataset_name].drop(columns)
+        return SimulationCollection(output)
 
     def take(
         self, n: int, at: str = "random", mode: Literal["local", "global"] = "local"

--- a/python/opencosmo/collection/simulation/simulation.py
+++ b/python/opencosmo/collection/simulation/simulation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Mapping, Optional, Self
 
 from opencosmo.collection import structure as sc
+from opencosmo.column.select import do_multi_dataset_selections
 from opencosmo.dataset import Dataset
 from opencosmo.io.schema import FileEntry, make_schema
 
@@ -39,6 +40,9 @@ class SimulationCollection(dict):
 
     def __init__(self, datasets: Mapping[str, Dataset | Collection]):
         self.update(datasets)
+        dtypes = set(type(ds) for ds in datasets.values())
+        assert len(dtypes) == 1
+        self.__dtype = dtypes.pop()
 
     def __enter__(self):
         return self
@@ -203,7 +207,7 @@ class SimulationCollection(dict):
         """
         return self.__map("filter", *masks, **kwargs)
 
-    def select(self, *args, **kwargs) -> Self:
+    def select(self, *args, **kwargs) -> SimulationCollection:
         """
         Select a set of columns in the datasets in this collection. This method
         calls the underlying method in :class:`opencosmo.Dataset`, or
@@ -211,6 +215,10 @@ class SimulationCollection(dict):
         its behavior and arguments can vary depending on what this collection
         contains. See the documentation for those objects to determine
         the expected arguments.
+
+        If the collection holds datasets with different column sets (e.g a matched
+        gravity-only and hydro sim) it will make a best-effort attempt to distribute
+        the selections to the relevant dataset.
 
         Parameters
         ----------
@@ -227,7 +235,11 @@ class SimulationCollection(dict):
             A new collection with only the specified columns
 
         """
-        return self.__map("select", *args, **kwargs)
+        if self.__dtype is not Dataset:
+            return self.__map("select", *args, **kwargs)
+
+        output = do_multi_dataset_selections(self, args, kwargs)
+        return SimulationCollection(output)
 
     def drop(self, *args, **kwargs) -> Self:
         """

--- a/python/opencosmo/collection/structure/structure.py
+++ b/python/opencosmo/collection/structure/structure.py
@@ -22,6 +22,7 @@ from opencosmo.collection.lightcone import lightcone as lc
 from opencosmo.collection.structure import evaluate
 from opencosmo.collection.structure import io as sio
 from opencosmo.column.column import DerivedScalarValue
+from opencosmo.column.select import do_multi_dataset_selections
 from opencosmo.dataset.formats import verify_format
 from opencosmo.index.unary import get_length
 from opencosmo.io.schema import FileEntry, make_schema
@@ -937,6 +938,7 @@ class StructureCollection:
 
     def select(
         self,
+        *single_selections,
         mode: str = "global",
         **column_selections: str | Iterable[str] | dict,
     ) -> StructureCollection:
@@ -1011,8 +1013,54 @@ class StructureCollection:
         ValueError
             If the specified dataset is not found in the collection.
         """
-        if not column_selections:
+        if not column_selections and not single_selections:
             return self
+
+        kwargs_found = set(column_selections.keys())
+        if not kwargs_found.intersection(self.keys()) or single_selections:
+            if any(
+                isinstance(selection, DerivedScalarValue)
+                for selection in column_selections.values()
+            ):
+                raise ValueError(
+                    "Scalar values cannot be retrieved from a StructureCollection directly. Use `collection[dataset].select(scalar_expression)`"
+                )
+            datasets = {}
+
+            def collect_leaves(collection, path=()):
+                if not collection.__hide_source:
+                    datasets[path + (collection.__source.dtype,)] = collection.__source
+                for name, ds in collection.__get_datasets().items():
+                    if isinstance(ds, StructureCollection):
+                        collect_leaves(ds, path + (name,))
+                    else:
+                        datasets[path + (name,)] = ds
+
+            collect_leaves(self)
+            selected = do_multi_dataset_selections(
+                datasets, single_selections, column_selections, mode
+            )
+
+            def rebuild(collection, path=()):
+                source_path = path + (collection.__source.dtype,)
+                new_source = selected.get(source_path, collection.__source)
+                new_datasets = {}
+                for name, ds in collection.__get_datasets().items():
+                    dataset_path = path + (name,)
+                    if isinstance(ds, StructureCollection):
+                        new_datasets[name] = rebuild(ds, dataset_path)
+                    else:
+                        new_datasets[name] = selected[dataset_path]
+                return StructureCollection(
+                    new_source,
+                    new_datasets,
+                    collection.__hide_source,
+                    collection.__handler,
+                    collection.__derived_columns,
+                )
+
+            return rebuild(self)
+
         new_source = self.__source
         new_datasets = {}
 

--- a/python/opencosmo/collection/structure/structure.py
+++ b/python/opencosmo/collection/structure/structure.py
@@ -938,89 +938,95 @@ class StructureCollection:
 
     def select(
         self,
-        *single_selections,
+        *select_args,
         mode: str = "global",
-        **column_selections: str | Iterable[str] | dict,
+        **select_kwargs: str | Iterable[str] | dict,
     ) -> StructureCollection:
         """
-        Update a dataset in the collection collection to only include the
-        columns specified. The name of the arguments to this function should be
-        dataset names. For example:
+        Select columns from the datasets in this collection.
+
+        By default, column names and derived columns are matched to the datasets
+        that contain their required columns. This works across nested structure
+        collections, so dataset names do not usually need to be specified:
+
+        .. code-block:: python
+
+            momentum = oc.col("gal_mass_star") * oc.col("gal_com_vx")
+            collection = collection.select(
+                "fof_halo_mass",
+                "gal_mass_star",
+                gal_momentum=momentum,
+            )
+
+        Exact names must exist in at least one dataset. Wildcards are applied to
+        every dataset and leave datasets with no matches unchanged. A column or
+        derived expression that can be resolved by multiple datasets is selected
+        from each of them.
+
+        To target particular datasets explicitly, use dataset names as keyword
+        arguments. This legacy form is useful when the same column name appears in
+        several datasets. Nested collections and derived columns can also be targeted
+        with dictionaries:
 
         .. code-block:: python
 
             collection = collection.select(
-                halo_properties = ["fof_halo_mass", "sod_halo_mass", "sod_halo_cdelta"],
-                dm_particles = ["x", "y", "z"]
+                halo_properties=["fof_halo_mass", "sod_halo_mass"],
+                dm_particles=["x", "y", "z"],
+                galaxies={"galaxy_properties": ["gal_mass_star"]},
             )
 
-        Datasets that do not appear in the argument list will not be modified. You can
-        remove entire datasets from the collection with
-        :py:meth:`with_datasets <opencosmo.StructureCollection.with_datasets>`
-
-        The :py:class:`opencosmo.Dataset` class supports creating derived columns as part of
-        a :py:meth:`select <opencosmo.Dataset.select>` call. You can do the same here, with
-        the following pattern:
+        In the explicit form, a derived selection is represented by ``columns`` and
+        ``derived_columns`` entries:
 
         .. code-block:: python
 
-            halo_px = oc.col("fof_halo_mass")*oc.col("fof_halo_com_Vx")
             collection = collection.select(
-                halo_properties = {
-                    columns = ["fof_halo_mass", "sod_halo_mass", "sod_halo_cdelta"],
-                    derived_columns = {"fof_halo_px": halo_px}
-                }
+                halo_properties={
+                    "columns": ["fof_halo_mass"],
+                    "derived_columns": {
+                        "fof_halo_px": oc.col("fof_halo_mass")
+                        * oc.col("fof_halo_com_vx")
+                    },
+                },
             )
-
-        For nested structure collections, such as galaxies within halos, you can pass
-        a nested dictionary:
-
-        .. code-block:: python
-
-            collection = oc.open("haloproperties.hdf5", "haloparticles.hdf5", "galaxyproperties.hdf5", "galaxyparticles.hdf5")
-
-            collection = collection.select(
-                halo_properties = ["fof_halo_mass", "sod_halo_mass", "sod_halo_cdelta"],
-                dm_particles = ["x", "y", "z"]
-                galaxies = {
-                    "galaxy_properties": ["gal_mass_bar", "gal_mass_star"],
-                    "star_particles": ["x", "y", "z"]
-                }
-            )
-
 
         Parameters
         ----------
+        *select_args : str or Iterable[str]
+            Column names or wildcard patterns to match automatically across all
+            datasets in the collection.
         mode : str, "local" or "global", default = "global"
             Controls how scalar reductions nested inside derived column
             expressions are computed when running under MPI. Defaults to
             ``"global"`` (cross-rank); pass ``"local"`` for per-rank scalars.
             Forwarded to each underlying ``Dataset.select`` call.
-
-        **column_selections : str | Iterable[str] | dict[str, Iterable[str]]
-            The columns to select from a given dataset or sub-collection
-
-        dataset : str
-            The dataset to select from.
+        **select_kwargs : Column or dataset selection
+            Derived columns to route automatically, or explicit selections keyed
+            by dataset name. Explicit selections may be a column name, an iterable
+            of names, or a nested selection dictionary.
 
         Returns
         -------
         StructureCollection
-            A new collection with only the selected columns for the specified dataset.
+            A new collection containing the selected columns. Datasets without an
+            applicable automatic selection are unchanged.
 
         Raises
         -------
         ValueError
-            If the specified dataset is not found in the collection.
+            If an exact column or derived-column dependency cannot be found in any
+            dataset, an explicitly named dataset does not exist, or a scalar
+            reduction is selected directly from the collection.
         """
-        if not column_selections and not single_selections:
+        if not select_kwargs and not select_args:
             return self
 
-        kwargs_found = set(column_selections.keys())
-        if not kwargs_found.intersection(self.keys()) or single_selections:
+        kwargs_found = set(select_kwargs.keys())
+        if not kwargs_found.intersection(self.keys()) or select_args:
             if any(
                 isinstance(selection, DerivedScalarValue)
-                for selection in column_selections.values()
+                for selection in select_kwargs.values()
             ):
                 raise ValueError(
                     "Scalar values cannot be retrieved from a StructureCollection directly. Use `collection[dataset].select(scalar_expression)`"
@@ -1038,7 +1044,7 @@ class StructureCollection:
 
             collect_leaves(self)
             selected = do_multi_dataset_selections(
-                datasets, single_selections, column_selections, mode
+                datasets, select_args, select_kwargs, mode
             )
 
             def rebuild(collection, path=()):
@@ -1064,7 +1070,7 @@ class StructureCollection:
         new_source = self.__source
         new_datasets = {}
 
-        for dataset, columns in column_selections.items():
+        for dataset, columns in select_kwargs.items():
             if isinstance(columns, dict) and (
                 "columns" in columns or "derived_columns" in columns
             ):

--- a/python/opencosmo/collection/structure/structure.py
+++ b/python/opencosmo/collection/structure/structure.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    cast,
 )
 from warnings import warn
 
@@ -22,7 +23,7 @@ from opencosmo.collection.lightcone import lightcone as lc
 from opencosmo.collection.structure import evaluate
 from opencosmo.collection.structure import io as sio
 from opencosmo.column.column import DerivedScalarValue
-from opencosmo.column.select import do_multi_dataset_selections
+from opencosmo.column.select import do_multi_dataset_drops, do_multi_dataset_selections
 from opencosmo.dataset.formats import verify_format
 from opencosmo.index.unary import get_length
 from opencosmo.io.schema import FileEntry, make_schema
@@ -155,6 +156,41 @@ class StructureCollection:
             self.__source.meta_columns, "galaxies" in self.__datasets
         )
         return self.__datasets
+
+    def __leaf_datasets(
+        self, path: tuple[str, ...] = ()
+    ) -> dict[tuple[str, ...], oc.Dataset]:
+        datasets = {}
+        if not self.__hide_source:
+            datasets[path + (self.__source.dtype,)] = self.__source
+        for name, dataset in self.__get_datasets().items():
+            if isinstance(dataset, StructureCollection):
+                datasets.update(dataset.__leaf_datasets(path + (name,)))
+            else:
+                datasets[path + (name,)] = dataset
+        return datasets
+
+    def __rebuild_hierarchy(
+        self,
+        datasets: Mapping[tuple[str, ...], oc.Dataset],
+        path: tuple[str, ...] = (),
+    ) -> StructureCollection:
+        source_path = path + (self.__source.dtype,)
+        new_source = datasets.get(source_path, self.__source)
+        new_datasets: dict[str, oc.Dataset | StructureCollection] = {}
+        for name, dataset in self.__get_datasets().items():
+            dataset_path = path + (name,)
+            if isinstance(dataset, StructureCollection):
+                new_datasets[name] = dataset.__rebuild_hierarchy(datasets, dataset_path)
+            else:
+                new_datasets[name] = datasets[dataset_path]
+        return StructureCollection(
+            new_source,
+            new_datasets,
+            self.__hide_source,
+            self.__handler,
+            self.__derived_columns,
+        )
 
     def __repr__(self):
         structure_type = self.__source.header.file.data_type.split("_")[0] + "s"
@@ -1031,41 +1067,11 @@ class StructureCollection:
                 raise ValueError(
                     "Scalar values cannot be retrieved from a StructureCollection directly. Use `collection[dataset].select(scalar_expression)`"
                 )
-            datasets = {}
-
-            def collect_leaves(collection, path=()):
-                if not collection.__hide_source:
-                    datasets[path + (collection.__source.dtype,)] = collection.__source
-                for name, ds in collection.__get_datasets().items():
-                    if isinstance(ds, StructureCollection):
-                        collect_leaves(ds, path + (name,))
-                    else:
-                        datasets[path + (name,)] = ds
-
-            collect_leaves(self)
+            datasets = self.__leaf_datasets()
             selected = do_multi_dataset_selections(
                 datasets, select_args, select_kwargs, mode
             )
-
-            def rebuild(collection, path=()):
-                source_path = path + (collection.__source.dtype,)
-                new_source = selected.get(source_path, collection.__source)
-                new_datasets = {}
-                for name, ds in collection.__get_datasets().items():
-                    dataset_path = path + (name,)
-                    if isinstance(ds, StructureCollection):
-                        new_datasets[name] = rebuild(ds, dataset_path)
-                    else:
-                        new_datasets[name] = selected[dataset_path]
-                return StructureCollection(
-                    new_source,
-                    new_datasets,
-                    collection.__hide_source,
-                    collection.__handler,
-                    collection.__derived_columns,
-                )
-
-            return rebuild(self)
+            return self.__rebuild_hierarchy(selected)
 
         new_source = self.__source
         new_datasets = {}
@@ -1112,37 +1118,55 @@ class StructureCollection:
             self.__derived_columns,
         )
 
-    def drop(self, **columns_to_drop):
+    def drop(
+        self,
+        *drop_args: str | Iterable[str],
+        **columns_to_drop: str | Iterable[str] | dict,
+    ):
         """
-        Update the linked collection by dropping the specified columns
-        in the specified datasets. This method follows the exact same semantics as
-        :py:meth:`StructureCollection.select <opencosmo.StructureCollection.select>`.
-        Argument names should be datasets in this collection, and the argument
-        values should be a string, list of strings, or dictionary.
+        Drop columns by automatically matching their names to datasets in this
+        collection. Like :py:meth:`StructureCollection.select
+        <opencosmo.StructureCollection.select>`, this works across nested
+        structure collections; wildcards are applied to every dataset, while
+        datasets without a match are unchanged.
+
+        To target datasets explicitly, pass dataset names as keyword arguments.
+        Values may be a string, iterable of strings, or nested dictionary.
 
         Datasets that are not included will not be modified. You can drop
         entire datasets with :py:meth:`with_datasets <opencosmo.StructureCollection.with_datasets>`
 
         Parameters
         ----------
+        *drop_args : str or Iterable[str]
+            Column names or wildcard patterns to match automatically across all
+            datasets in the collection.
         **columns_to_drop : str | Iterable[str]
-            The columns to drop from the dataset.
-
-        dataset : str, optional
-            The dataset to select from. If None, the properties dataset is used.
+            Columns to drop from explicitly named datasets.
 
         Returns
         -------
         StructureCollection
-            A new collection with only the selected columns for the specified dataset.
+            A new collection with the specified columns dropped.
 
         Raises
         -------
         ValueError
             If the specified dataset is not found in the collection.
         """
-        if not columns_to_drop:
+        if not drop_args and not columns_to_drop:
             return self
+
+        if drop_args:
+            datasets = self.__leaf_datasets()
+            dropped = do_multi_dataset_drops(
+                datasets, cast("tuple[str | list[str], ...]", drop_args)
+            )
+            collection = self.__rebuild_hierarchy(dropped)
+            if not columns_to_drop:
+                return collection
+            return collection.drop(**columns_to_drop)
+
         new_source = self.__source
         new_datasets = {}
 
@@ -1156,7 +1180,11 @@ class StructureCollection:
             new_ds = self.__datasets[dataset_name]
             if isinstance(new_ds, oc.Dataset):
                 new_ds = new_ds.drop(columns)
-            elif isinstance(new_ds.StructureCollection):
+            elif isinstance(new_ds, StructureCollection):
+                if not isinstance(columns, dict):
+                    raise ValueError(
+                        "When working with nested structure collections, the argument should be a dictionary!"
+                    )
                 new_ds = new_ds.drop(**columns)
 
             new_datasets[dataset_name] = new_ds

--- a/python/opencosmo/column/column.py
+++ b/python/opencosmo/column/column.py
@@ -250,6 +250,11 @@ class Column:
         return set(self.__dep_map.values())
 
     @property
+    def requires_names(self) -> set[str]:
+        """Return all leaf column names in the expression tree."""
+        return self._traverse_names()
+
+    @property
     def produces(self):
         return None if self.name is None else set([self.name])
 
@@ -632,6 +637,9 @@ class ConstructedColumn(Protocol):
     def requires(self) -> set[UUID]: ...
 
     @property
+    def requires_names(self) -> set[str]: ...
+
+    @property
     def dep_map(self) -> dict[str, UUID] | None: ...
 
     @property
@@ -702,6 +710,13 @@ class RawColumn:
         return {self.__dep_uuid}
 
     @property
+    def requires_names(self) -> set[str]:
+        """Return the underlying column name when this is an alias, else empty set."""
+        if self.__alias is None:
+            return set()
+        return {self.__name}
+
+    @property
     def dep_map(self) -> dict[str, UUID]:
         if self.__alias is None:
             return {}
@@ -768,9 +783,13 @@ class DerivedScalarValue:
 
     def _traverse_names(self) -> set[str]:
         vals: set[str] = set()
-        if isinstance(self.lhs, (DerivedScalarValue, Column)):
+        if isinstance(self.lhs, str):
+            vals.add(self.lhs)
+        elif isinstance(self.lhs, (DerivedScalarValue, Column)):
             vals |= self.lhs._traverse_names()
-        if isinstance(self.rhs, (DerivedScalarValue, Column)):
+        if isinstance(self.rhs, str):
+            vals.add(self.rhs)
+        elif isinstance(self.rhs, (DerivedScalarValue, Column)):
             vals |= self.rhs._traverse_names()
         return vals
 
@@ -789,6 +808,11 @@ class DerivedScalarValue:
                 f"DerivedScalarValue '{self.name}' has not been bound yet."
             )
         return set(self.__dep_map.values())
+
+    @property
+    def requires_names(self) -> set[str]:
+        """Return all leaf column names in the expression tree."""
+        return self._traverse_names()
 
     @property
     def produces(self):

--- a/python/opencosmo/column/select.py
+++ b/python/opencosmo/column/select.py
@@ -48,7 +48,7 @@ def get_column_selection(
 
 
 def do_multi_dataset_selections(
-    datasets: dict[str, Dataset],
+    datasets: dict[Any, Dataset],
     select_args: tuple[str | list[str], ...],
     select_kwargs: dict[str, Any],
     mode: str = "global",
@@ -77,9 +77,35 @@ def do_multi_dataset_selections(
     return new_datasets
 
 
+def do_multi_dataset_drops(
+    datasets: dict[Any, Dataset],
+    drop_args: tuple[str | list[str], ...],
+):
+    columns_by_ds = {name: set(ds.columns) for name, ds in datasets.items()}
+    length_by_ds = {name: len(ds) for name, ds in datasets.items()}
+    args_by_ds, _ = build_multi_dataset_selections(
+        columns_by_ds, length_by_ds, drop_args, {}
+    )
+    new_datasets = {}
+    for name, dataset in datasets.items():
+        ds_args = args_by_ds.get(name, [])
+        if not ds_args:
+            new_datasets[name] = dataset
+            continue
+        try:
+            new_ds = dataset.drop(*ds_args)
+        # Do NOT fail if the only selections are wildcards, just return the raw dataset
+        except MissingColumnError:
+            if not all("*" in ds_arg for ds_arg in ds_args):
+                raise
+            new_ds = dataset
+        new_datasets[name] = new_ds
+    return new_datasets
+
+
 def build_multi_dataset_selections(
-    columns_by_ds: dict[str, set[str]],
-    ds_lengths: dict[str, int],
+    columns_by_ds: dict[Any, set[str]],
+    ds_lengths: dict[Any, int],
     select_args: tuple[str | list[str], ...],
     select_kwargs: dict[str, Any],
 ):

--- a/python/opencosmo/column/select.py
+++ b/python/opencosmo/column/select.py
@@ -1,7 +1,24 @@
 """ """
 
+from __future__ import annotations
+
 import re
-from typing import Iterable
+from typing import TYPE_CHECKING, Any, Iterable
+
+import numpy as np
+
+from opencosmo.column.column import (
+    Column,
+    DerivedScalarValue,
+    RawColumn,
+)
+
+if TYPE_CHECKING:
+    from opencosmo import Dataset
+
+
+class MissingColumnError(ValueError):
+    pass
 
 
 def get_column_selection(
@@ -28,6 +45,121 @@ def get_column_selection(
 
     wildcard_matches = __evaluate_wildcards(select_from, wildcards)
     return complete_matches.union(wildcard_matches), complete_missing
+
+
+def do_multi_dataset_selections(
+    datasets: dict[str, Dataset],
+    select_args: tuple[str | list[str], ...],
+    select_kwargs: dict[str, Any],
+    mode: str = "global",
+):
+    mode = select_kwargs.pop("mode", mode)
+    columns_by_ds = {name: set(ds.columns) for name, ds in datasets.items()}
+    length_by_ds = {name: len(ds) for name, ds in datasets.items()}
+    args_by_ds, kwargs_by_ds = build_multi_dataset_selections(
+        columns_by_ds, length_by_ds, select_args, select_kwargs
+    )
+    new_datasets = {}
+    for name, dataset in datasets.items():
+        ds_args = args_by_ds.get(name, [])
+        ds_kwargs = kwargs_by_ds.get(name, {})
+        if not ds_args and not ds_kwargs:
+            new_datasets[name] = dataset
+            continue
+        try:
+            new_ds = dataset.select(*ds_args, **ds_kwargs, mode=mode)
+        # Do NOT fail if the only selections are wildcards, just return the raw dataset
+        except MissingColumnError:
+            if not all("*" in ds_arg for ds_arg in ds_args) or ds_kwargs:
+                raise
+            new_ds = dataset
+        new_datasets[name] = new_ds
+    return new_datasets
+
+
+def build_multi_dataset_selections(
+    columns_by_ds: dict[str, set[str]],
+    ds_lengths: dict[str, int],
+    select_args: tuple[str | list[str], ...],
+    select_kwargs: dict[str, Any],
+):
+    flat_args = []
+    for selection in select_args:
+        if isinstance(selection, str):
+            flat_args.append(selection)
+        else:
+            flat_args.extend(selection)
+    assert set(columns_by_ds.keys()) == set(ds_lengths.keys())
+
+    wildcards = []
+    output_args: dict[Any, list[str]] = {name: [] for name in columns_by_ds.keys()}
+    missing = set()
+    for arg in flat_args:
+        if not isinstance(arg, str):
+            raise ValueError("Column selection arguments must be strings!")
+        if "*" in arg:
+            wildcards.append(arg)
+            continue
+        datasets_with_column = set(
+            ds_name for ds_name, cols in columns_by_ds.items() if arg in cols
+        )
+        if not datasets_with_column:
+            missing.add(arg)
+            continue
+        for ds_name in datasets_with_column:
+            output_args[ds_name].append(arg)
+    if missing:
+        raise MissingColumnError(
+            f"Columns {missing} could not be found in any datasets!"
+        )
+    for ds_selection in output_args.values():
+        ds_selection.extend(wildcards)
+    output_kwargs: dict[Any, dict[str, Any]] = {
+        name: {} for name in columns_by_ds.keys()
+    }
+    missing = set()
+    missing_lengths = set()
+    for kwarg_name, kwarg_value in select_kwargs.items():
+        if isinstance(kwarg_value, np.ndarray):
+            col_length = len(kwarg_value)
+            datasets_with_required_length = set(
+                ds_name
+                for ds_name, length in ds_lengths.items()
+                if length == col_length
+            )
+            if not datasets_with_required_length:
+                missing_lengths.add(kwarg_name)
+                continue
+            for ds_name in datasets_with_required_length:
+                output_kwargs[ds_name][kwarg_name] = kwarg_value
+            continue
+
+        elif not isinstance(
+            kwarg_value, (Column, DerivedScalarValue, RawColumn)
+        ) and not hasattr(kwarg_value, "requires_names"):
+            raise ValueError(
+                f"Received unknown column type {kwarg_name} = {type(kwarg_value)}"
+            )
+        column_requires = kwarg_value.requires_names
+        datasets_with_required_columns = set(
+            ds_name
+            for ds_name, ds_columns in columns_by_ds.items()
+            if column_requires.issubset(ds_columns)
+        )
+        if not datasets_with_required_columns:
+            missing.add(kwarg_name)
+        for ds_name in datasets_with_required_columns:
+            output_kwargs[ds_name][kwarg_name] = kwarg_value
+
+    if missing:
+        raise MissingColumnError(
+            f"The columns required by {missing} do not exist in any of the datasets! Perhaps you mispelled some names?"
+        )
+    elif missing_lengths:
+        raise ValueError(
+            f"The arrays passed in {missing_lengths} do not match the length of any dataset!"
+        )
+    return output_args, output_kwargs
 
 
 def __evaluate_wildcards(select_from: set[str], wildcards: Iterable[str]):

--- a/python/opencosmo/dataset/state.py
+++ b/python/opencosmo/dataset/state.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from opencosmo.column.cache import ColumnCache
 from opencosmo.column.column import RawColumn
-from opencosmo.column.select import get_column_selection
+from opencosmo.column.select import MissingColumnError, get_column_selection
 from opencosmo.dataset.columns import add_columns, resort
 from opencosmo.dataset.instantiate import instantiate_dataset
 from opencosmo.dataset.output import get_derived_column_names, make_dataset_schema
@@ -427,11 +427,11 @@ def select(state: DatasetState, columns: set[str], drop: bool = False) -> Datase
     """
     selections, missing = get_column_selection(state.columns, columns)
     if missing:
-        raise ValueError(
+        raise MissingColumnError(
             f"Columns are included that are not in this dataset: {missing}"
         )
     elif not selections and columns:
-        raise ValueError("No columns matched the provided wildcards!")
+        raise MissingColumnError("No columns matched the provided wildcards!")
 
     if drop:
         selections = set(state.columns) - selections

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -913,6 +913,33 @@ def test_data_link_drop(halo_paths):
     assert found_dm_particles
 
 
+def test_drop_nested_structures_automatically(halo_paths, galaxy_paths):
+    collection = oc.open(*halo_paths, *galaxy_paths)
+
+    dropped = collection.drop("fof_halo_mass", "gal_mass_star", "x")
+
+    assert "fof_halo_mass" not in dropped["halo_properties"].columns
+    assert "x" not in dropped["dm_particles"].columns
+    assert "gal_mass_star" not in dropped["galaxies"]["galaxy_properties"].columns
+    assert "x" not in dropped["galaxies"]["star_particles"].columns
+
+
+def test_drop_nested_structures_by_dataset_key(halo_paths, galaxy_paths):
+    collection = oc.open(*halo_paths, *galaxy_paths)
+
+    dropped = collection.drop(
+        halo_properties=["fof_halo_mass"],
+        galaxies={
+            "galaxy_properties": ["gal_mass_star"],
+            "star_particles": ["x"],
+        },
+    )
+
+    assert "fof_halo_mass" not in dropped["halo_properties"].columns
+    assert "gal_mass_star" not in dropped["galaxies"]["galaxy_properties"].columns
+    assert "x" not in dropped["galaxies"]["star_particles"].columns
+
+
 def test_link_halos_to_galaxies(halo_paths, galaxy_paths):
     galaxy_path = galaxy_paths[0]
     collection = oc.open(*halo_paths, galaxy_path)

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -274,6 +274,31 @@ def test_select_nested_structures_with_derived(halo_paths, galaxy_paths):
         assert set(halo["galaxies"]["star_particles"].columns) == {"x", "y", "z"}
 
 
+def test_select_nested_structures_automatically(halo_paths, galaxy_paths):
+    collection = oc.open(*halo_paths, *galaxy_paths)
+    galaxy_properties = collection["galaxies"]["galaxy_properties"]
+    expected_px = galaxy_properties.select(
+        px=oc.col("gal_mass_star") * oc.col("gal_com_vx")
+    ).get_data("numpy")
+
+    collection = collection.select(
+        "fof_halo_mass",
+        "gal_mass_star",
+        gal_star_px=oc.col("gal_mass_star") * oc.col("gal_com_vx"),
+    )
+
+    assert set(collection["halo_properties"].columns) == {"fof_halo_mass"}
+    galaxies = collection["galaxies"]
+    assert set(galaxies["galaxy_properties"].columns) == {
+        "gal_mass_star",
+        "gal_star_px",
+    }
+    galaxy_data = galaxies["galaxy_properties"].get_data("numpy")
+    assert np.all(galaxy_data["gal_star_px"] == expected_px)
+    assert "x" in collection["dm_particles"].columns
+    assert "x" in galaxies["star_particles"].columns
+
+
 def test_visit_single(halo_paths):
     collection = oc.open(*halo_paths).take(100)
     spec = {

--- a/test/test_multi_dataset_select.py
+++ b/test/test_multi_dataset_select.py
@@ -115,6 +115,51 @@ def test_simulation_collection_routes_across_different_column_sets(snapshot_path
     assert np.all(hydro_data["stellar_fraction"] == expected)
 
 
+def test_simulation_collection_drop_routes_across_different_column_sets(snapshot_path):
+    gravity = oc.open(snapshot_path / "haloproperties.hdf5")
+    hydro = oc.open(snapshot_path / "galaxyproperties.hdf5")
+    collection = oc.SimulationCollection({"gravity": gravity, "hydro": hydro})
+
+    dropped = collection.drop("fof_halo_mass", "gal_mass_star")
+
+    assert "fof_halo_mass" not in dropped["gravity"].columns
+    assert "gal_mass_star" not in dropped["hydro"].columns
+    assert "gal_mass" in dropped["hydro"].columns
+
+
+def test_simulation_collection_drop_wildcard_leaves_unmatched_datasets_unchanged(
+    snapshot_path,
+):
+    gravity = oc.open(snapshot_path / "haloproperties.hdf5")
+    hydro = oc.open(snapshot_path / "galaxyproperties.hdf5")
+    collection = oc.SimulationCollection({"gravity": gravity, "hydro": hydro})
+
+    dropped = collection.drop("gal_mass_*")
+
+    assert dropped["gravity"].columns == gravity.columns
+    assert not any(name.startswith("gal_mass_") for name in dropped["hydro"].columns)
+
+
+def test_simulation_collection_drop_rejects_missing_column(snapshot_path):
+    gravity = oc.open(snapshot_path / "haloproperties.hdf5")
+    hydro = oc.open(snapshot_path / "galaxyproperties.hdf5")
+    collection = oc.SimulationCollection({"gravity": gravity, "hydro": hydro})
+
+    with pytest.raises(MissingColumnError):
+        collection.drop("not_a_column")
+
+
+def test_simulation_collection_drop_by_dataset_key(snapshot_path):
+    gravity = oc.open(snapshot_path / "haloproperties.hdf5")
+    hydro = oc.open(snapshot_path / "galaxyproperties.hdf5")
+    collection = oc.SimulationCollection({"gravity": gravity, "hydro": hydro})
+
+    dropped = collection.drop(gravity=["fof_halo_mass"], hydro=["gal_mass_star"])
+
+    assert "fof_halo_mass" not in dropped["gravity"].columns
+    assert "gal_mass_star" not in dropped["hydro"].columns
+
+
 def test_structure_collection_ignores_unmatched_wildcard_on_other_datasets(halo_paths):
     collection = oc.open(*halo_paths)
     selected = collection.select("sod_halo_mass*")

--- a/test/test_multi_dataset_select.py
+++ b/test/test_multi_dataset_select.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from opencosmo.column.select import (
+    MissingColumnError,
+    build_multi_dataset_selections,
+)
+
+import opencosmo as oc
+
+
+@pytest.fixture
+def dataset_columns():
+    return {
+        "gravity": {"id", "mass", "x"},
+        "hydro": {"id", "mass", "temperature"},
+    }
+
+
+@pytest.fixture
+def halo_paths(snapshot_path):
+    return [
+        snapshot_path / "haloproperties.hdf5",
+        snapshot_path / "haloparticles.hdf5",
+        snapshot_path / "sodproperties.hdf5",
+    ]
+
+
+def test_routes_columns_and_wildcards(dataset_columns):
+    args, _ = build_multi_dataset_selections(
+        dataset_columns,
+        {"gravity": 3, "hydro": 5},
+        ("x", "temperature", "m*"),
+        {},
+    )
+
+    assert set(args["gravity"]) == {"x", "m*"}
+    assert set(args["hydro"]) == {"temperature", "m*"}
+
+
+def test_routes_derived_columns_by_dependencies(dataset_columns):
+    _, kwargs = build_multi_dataset_selections(
+        dataset_columns,
+        {"gravity": 3, "hydro": 5},
+        (),
+        {
+            "mass_squared": oc.col("mass") ** 2,
+            "thermal_mass": oc.col("mass") * oc.col("temperature"),
+        },
+    )
+
+    assert set(kwargs["gravity"]) == {"mass_squared"}
+    assert set(kwargs["hydro"]) == {"mass_squared", "thermal_mass"}
+
+
+def test_routes_arrays_by_dataset_length(dataset_columns):
+    gravity_values = np.arange(3)
+    hydro_values = np.arange(5)
+    _, kwargs = build_multi_dataset_selections(
+        dataset_columns,
+        {"gravity": 3, "hydro": 5},
+        (),
+        {"gravity_rank": gravity_values, "hydro_rank": hydro_values},
+    )
+
+    assert kwargs["gravity"]["gravity_rank"] is gravity_values
+    assert kwargs["hydro"]["hydro_rank"] is hydro_values
+
+
+def test_rejects_array_that_matches_no_dataset_length(dataset_columns):
+    with pytest.raises(ValueError, match="rank"):
+        build_multi_dataset_selections(
+            dataset_columns,
+            {"gravity": 3, "hydro": 5},
+            (),
+            {"rank": np.arange(4)},
+        )
+
+
+@pytest.mark.parametrize(
+    ("args", "kwargs"),
+    [
+        (("missing",), {}),
+        ((), {"derived": oc.col("missing") * 2}),
+    ],
+)
+def test_rejects_selections_missing_from_every_dataset(dataset_columns, args, kwargs):
+    with pytest.raises(MissingColumnError):
+        build_multi_dataset_selections(
+            dataset_columns,
+            {"gravity": 3, "hydro": 5},
+            args,
+            kwargs,
+        )
+
+
+def test_simulation_collection_routes_across_different_column_sets(snapshot_path):
+    gravity = oc.open(snapshot_path / "haloproperties.hdf5")
+    hydro = oc.open(snapshot_path / "galaxyproperties.hdf5")
+    collection = oc.SimulationCollection({"gravity": gravity, "hydro": hydro})
+
+    selected = collection.select(
+        "fof_halo_mass",
+        "gal_mass_star",
+        stellar_fraction=oc.col("gal_mass_star") / oc.col("gal_mass"),
+    )
+
+    assert set(selected["gravity"].columns) == {"fof_halo_mass"}
+    assert set(selected["hydro"].columns) == {"gal_mass_star", "stellar_fraction"}
+    hydro_data = selected["hydro"].get_data("numpy")
+    expected = hydro.select(
+        value=oc.col("gal_mass_star") / oc.col("gal_mass")
+    ).get_data("numpy")
+    assert np.all(hydro_data["stellar_fraction"] == expected)
+
+
+def test_structure_collection_ignores_unmatched_wildcard_on_other_datasets(halo_paths):
+    collection = oc.open(*halo_paths)
+    selected = collection.select("sod_halo_mass*")
+
+    assert selected["halo_properties"].columns
+    assert all(
+        name.startswith("sod_halo_mass") for name in selected["halo_properties"].columns
+    )
+    assert selected["dm_particles"].columns == collection["dm_particles"].columns
+
+
+def test_structure_collection_rejects_scalar_selection(halo_paths):
+    collection = oc.open(*halo_paths)
+
+    with pytest.raises(ValueError, match="Scalar values cannot be retrieved"):
+        collection.select(mean_mass=oc.col("fof_halo_mass").mean())

--- a/test/test_requires_names.py
+++ b/test/test_requires_names.py
@@ -1,0 +1,196 @@
+"""Unit tests for the requires_names property on column types."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+from opencosmo.column.column import (
+    EvaluatedColumn,
+    RawColumn,
+    col,
+)
+from opencosmo.column.evaluate import EvaluateStrategy
+
+# ---------------------------------------------------------------------------
+# Column
+# ---------------------------------------------------------------------------
+
+
+class TestColumnRequiresNames:
+    def test_simple_leaf_unbound(self):
+        c = col("fof_halo_mass")
+        assert c.requires_names == {"fof_halo_mass"}
+
+    def test_binary_expression_unbound(self):
+        expr = col("fof_halo_mass") * col("fof_halo_com_vx")
+        assert expr.requires_names == {"fof_halo_mass", "fof_halo_com_vx"}
+
+    def test_chained_expression_unbound(self):
+        expr = col("a") * col("b") + col("c")
+        assert expr.requires_names == {"a", "b", "c"}
+
+    def test_scalar_operand_not_included(self):
+        # Multiplying by a plain int/float should not add any name
+        expr = col("fof_halo_mass") * 5
+        assert expr.requires_names == {"fof_halo_mass"}
+
+    def test_returns_fresh_set(self):
+        c = col("fof_halo_mass")
+        s1 = c.requires_names
+        s2 = c.requires_names
+        assert s1 == s2
+        s1.add("extra")
+        assert "extra" not in c.requires_names
+
+    def test_bound_column_same_result(self):
+        expr = col("fof_halo_mass") * col("fof_halo_com_vx")
+        name_to_uuid = {
+            "fof_halo_mass": uuid4(),
+            "fof_halo_com_vx": uuid4(),
+        }
+        bound = expr.bind(name_to_uuid)
+        assert bound.requires_names == {"fof_halo_mass", "fof_halo_com_vx"}
+
+    def test_duplicate_names_deduplicated(self):
+        # Same column used twice in an expression
+        m = col("fof_halo_mass")
+        expr = m * m
+        assert expr.requires_names == {"fof_halo_mass"}
+
+
+# ---------------------------------------------------------------------------
+# RawColumn
+# ---------------------------------------------------------------------------
+
+
+class TestRawColumnRequiresNames:
+    def test_plain_raw_column_empty(self):
+        rc = RawColumn("fof_halo_mass", "halo mass")
+        assert rc.requires_names == set()
+
+    def test_alias_unbound_returns_underlying_name(self):
+        rc = RawColumn("fof_halo_mass", "halo mass", alias="mass")
+        assert rc.requires_names == {"fof_halo_mass"}
+
+    def test_alias_bound_returns_underlying_name(self):
+        dep_uuid = uuid4()
+        rc = RawColumn(
+            "fof_halo_mass",
+            "halo mass",
+            alias="mass",
+            _dep_uuid=dep_uuid,
+        )
+        assert rc.requires_names == {"fof_halo_mass"}
+
+    def test_alias_bind_then_requires_names(self):
+        rc = RawColumn("fof_halo_mass", "halo mass", alias="mass")
+        name_to_uuid = {"fof_halo_mass": uuid4()}
+        bound = rc.bind(name_to_uuid)
+        assert bound.requires_names == {"fof_halo_mass"}
+
+    def test_plain_returns_fresh_set(self):
+        rc = RawColumn("fof_halo_mass", "halo mass")
+        s = rc.requires_names
+        s.add("extra")
+        assert rc.requires_names == set()
+
+
+# ---------------------------------------------------------------------------
+# DerivedScalarValue
+# ---------------------------------------------------------------------------
+
+
+class TestDerivedScalarValueRequiresNames:
+    def test_simple_mean_unbound(self):
+        scalar = col("fof_halo_mass").mean()
+        assert scalar.requires_names == {"fof_halo_mass"}
+
+    def test_compound_scalar_arithmetic_unbound(self):
+        m = col("fof_halo_mass")
+        # (m - m.mean()) / m.std() — the outer Column wraps two DerivedScalarValues
+        # but the scalar itself (m.mean()) should only see "fof_halo_mass"
+        scalar = m.mean()
+        assert scalar.requires_names == {"fof_halo_mass"}
+
+    def test_scalar_arithmetic_between_scalars(self):
+        m = col("fof_halo_mass")
+        v = col("fof_halo_com_vx")
+        # scalar arithmetic: m.mean() + v.std() is a DerivedScalarValue
+        combined = m.mean() + v.std()
+        assert combined.requires_names == {"fof_halo_mass", "fof_halo_com_vx"}
+
+    def test_scalar_arithmetic_with_plain_number(self):
+        m = col("fof_halo_mass")
+        shifted = m.mean() + 1.0
+        assert shifted.requires_names == {"fof_halo_mass"}
+
+    def test_bound_scalar_same_result(self):
+        m = col("fof_halo_mass")
+        scalar = m.mean()
+        name_to_uuid = {"fof_halo_mass": uuid4()}
+        bound = scalar.bind(name_to_uuid)
+        assert bound.requires_names == {"fof_halo_mass"}
+
+    def test_returns_fresh_set(self):
+        scalar = col("fof_halo_mass").mean()
+        s1 = scalar.requires_names
+        s2 = scalar.requires_names
+        assert s1 == s2
+        s1.add("extra")
+        assert "extra" not in scalar.requires_names
+
+    def test_nested_column_expression_in_scalar(self):
+        # (col("a") * col("b")).mean() — the scalar's lhs is a Column
+        expr = (col("a") * col("b")).mean()
+        assert expr.requires_names == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# EvaluatedColumn
+# ---------------------------------------------------------------------------
+
+
+def _make_evaluated_column(requires, produces=None):
+    """Helper to build a minimal EvaluatedColumn for testing."""
+    if produces is None:
+        produces = {"out"}
+
+    def func(**kwargs):
+        return np.zeros(1)
+
+    func.__name__ = "func"
+    return EvaluatedColumn(
+        func,
+        requires,
+        produces,
+        "numpy",
+        {name: None for name in produces},
+        EvaluateStrategy.ROW_WISE,
+    )
+
+
+class TestEvaluatedColumnRequiresNames:
+    def test_unbound_returns_declared_names(self):
+        ec = _make_evaluated_column({"col_a", "col_b"})
+        assert ec.requires_names == {"col_a", "col_b"}
+
+    def test_bound_returns_same_names(self):
+        ec = _make_evaluated_column({"col_a", "col_b"})
+        name_to_uuid = {"col_a": uuid4(), "col_b": uuid4()}
+        bound = ec.bind(name_to_uuid)
+        assert bound.requires_names == {"col_a", "col_b"}
+
+    def test_returns_fresh_set(self):
+        ec = _make_evaluated_column({"col_a"})
+        s = ec.requires_names
+        s.add("extra")
+        assert ec.requires_names == {"col_a"}
+
+    def test_binding_does_not_alter_result(self):
+        ec = _make_evaluated_column({"col_a", "col_b"})
+        before = ec.requires_names
+        name_to_uuid = {"col_a": uuid4(), "col_b": uuid4()}
+        bound = ec.bind(name_to_uuid)
+        after = bound.requires_names
+        assert before == after

--- a/test/test_select.py
+++ b/test/test_select.py
@@ -2,6 +2,7 @@ import h5py
 import numpy as np
 import pytest
 from astropy.cosmology import units as cu
+from opencosmo.column.select import MissingColumnError
 
 import opencosmo as oc
 
@@ -114,7 +115,7 @@ def test_select_invalid_column(input_path):
     selected_cols = np.random.choice(cols, 10, replace=False)
     # add an invalid column
     selected_cols = np.append(selected_cols, "invalid_column")
-    with pytest.raises(ValueError):
+    with pytest.raises(MissingColumnError):
         dataset.select(selected_cols)
 
 


### PR DESCRIPTION
This PR introduces a better solution for selection columns in StructureCollections. Given a standard dataset selection syntax, It automatically attempts to infer which selections belong to which dataset, without the user having to specify. Manual specification remains available for backward compatibility and finer-grained control.

Also addresses #276 

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ArgonneCPAC/codesmith/OpenCosmo/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788719793&installation_model_id=428482&pr_number=279&repository=ArgonneCPAC%2FOpenCosmo&return_to=https%3A%2F%2Fgithub.com%2FArgonneCPAC%2FOpenCosmo%2Fpull%2F279&signature=c1a531bca331033654e446321b27a06d2f2465e0b2fc4219422ea1a492c2037b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->